### PR TITLE
Fixes cropped carousel items in Safari

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -61,5 +61,5 @@
 }
 
 .feature-item-content {
-    @apply sm:absolute h-full w-full box-border rounded-xl border-8 border-emeraldLangium dark:border-emeraldLangium sm:px-6 px-2 pb-6 mx-2 bg-emeraldLangium dark:bg-gray-900 shadow-lg;
+    @apply h-full w-full box-border rounded-xl border-8 border-emeraldLangium dark:border-emeraldLangium sm:px-6 px-2 pb-6 mx-2 sm:mx-0 bg-emeraldLangium dark:bg-gray-900 shadow-lg;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1454,7 +1454,8 @@ video {
 
 @media (min-width: 640px) {
   .feature-item-content {
-    position: absolute;
+    margin-left: 0px;
+    margin-right: 0px;
   }
 
   .feature-item-content {


### PR DESCRIPTION
This fixes a deviation of the carousel rendering between Chrome and Safari.

# ⬅️ Chrome | Safari ➡️

## Before
Before it looked on large screens like this (left: Chrome, right: Safari):

![before-lg](https://user-images.githubusercontent.com/743833/144007327-34504d64-224a-47ea-818a-a16b56b7321a.png)

## After

After applying this fix, it looks correct:

![after-lg](https://user-images.githubusercontent.com/743833/144007331-edf43248-6c8b-45b5-8ccf-6121f653bcb9.png)

This fix does not change rendering on small screens. Before and after look like this:

![before-after-sm](https://user-images.githubusercontent.com/743833/144007329-4ebc5779-f23e-4a63-9f18-5b9550a36b88.png)

