### PR TITLE
Grammar documentation

### DIFF
--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -240,7 +240,7 @@ but the following:
 person Bob
 Hello Sara !
 ```
-will result in an error message since the cross reference resolution will fail because a `Person` object with the ID of 'Sara' has not been instantiated even though 'Sara' is a valid `ID`.
+will result in an error message since the cross reference resolution will fail because a `Person` object with the name 'Sara' has not been defined, even though 'Sara' is a valid `ID`.
 
 #### Unordered Groups
 [NOTE] Unordered group are currently not supported but seems like it's being worked on. I think this is still valuable info that could be added to the documentation at a later stage if needed.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -357,7 +357,7 @@ The *entry rule* is a parser rule that defines the starting point of the parsing
  ```
 In this example, the *entry rule* `Model` defines a group of alternatives. The parser will go through the input document and try to parse a `Person` or a `Greeting` object and add it to the array `persons` or `greetings`, respectively. Thanks to the grouping and the cardinality of zero or many (`*`), the parser will go through the document until all inputs have been consumed.
 
-Not all parser rules need to be registered in the parser rule.
+Not all parser rules need to be registered in the entry parser rule.
 ```
 entry Model:
     (persons+=Person | greetings+=Greeting)*;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -68,19 +68,21 @@ A cardinality defines the number of elements in a given set. Four different card
 
 [QUESTION]Should we add examples of cardinalities here?
 #### Character Range
-The operator `..` is used to declare a character range. It is equivalent to the operator `-`in regular expression.
+The operator `..` is used to declare a character range. It is equivalent to the operator `-`in regular expression. It matches any character in between the left character and the right character (inclusive on both ends) depending on their UTF-16 code.
+
+[QUESTION] I could find where in the langium code base we parse this range. I assumed it would be based on String.prototype.charCodeAt() or something similar. Please correct if I'm wrong.
 
 ```
 terminal INT returns number: ('0'..'9')+;
 ```
 
-is equivalent to
+is equivalent to the regular expression:
 
 ```
 terminal INT returns number: /[0-9]+/;
 ```
 
-Here, INT is matched to one or more characters (by using the operand `+`) between '0' and '9' (inclusive).
+Here, INT is matched to one or more characters (by using the operand `+`, which defines a cardinality of 'one or many') between `0` and `9` (inclusive on both ends).
 
 #### Wildcard
 The operator `.` is used to match any character and is similar in regular expression.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -60,7 +60,7 @@ A cardinality defines the number of elements in a given set. Four different card
 4. one or many (operator `+`)
 
 #### Character Range
-The operator `..` is used to declare a character range. It is equivalent to the operator `-` in regular expression. It matches any character in between the left character and the right character (inclusive on both ends).
+The operator `..` is used to declare a character range. It is equivalent to the operator `-` within a character class in a regular expression. It matches any character in between the left character and the right character (inclusive on both ends).
 ```
 terminal INT returns number: ('0'..'9')+;
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -190,13 +190,17 @@ There are three different ways to assign an expression (right side) to a propert
     Paragraph:
         'paragraph' (sentences+=STRING)+;
     ```
-    [QUESTION] IS THIS DECLARATION VALID? OR SHOULD sentences BE ASSIGNED AN OTHER PARSER RULE INSTEAD OF A TERMINAL RULE?
-3. `?=` is used to assign a **value to a property of type boolean**. The value of the property of type `boolean` is set to `true` if the right part of the assignment is consume by the parser
+    Here, the property `sentences` will accept one or many expressions matching the terminal rule `STRING`. The expressions belong to a single group and must not be interrupted by other expressions. The parsing of a document containing:
+    ```
+    paragraph "The expression group " 3 "was interrupted"
+    ```
+    will throw an error since the `STRING` expressions are not continuous. It is however possible to interrupt and resume a sequence of expressions by using [hidden terminal symbols](#hidden-terminal-symbols).
+3. `?=` is used to assign a **value to a property of type boolean**. The value of the property of type `boolean` is set to `true` if the right part of the assignment is consumed by the parser
     ```
     Employee:
         'employee' name=ID (remote?='remote')?
     ```
-    Here the value of the property `remote` will be set to true if the keyword `remote` appears in the declaration.
+    Here the value of the property `remote` will be set to true if the keyword `remote` appears in the document.
 #### Cross-reference
 [TODO] CHECK IN MORE DETAILS, I DON'T UNDERSTAND THE SYNTAX AND HOW IT'S IMPLEMENTED
 #### Unordered Groups

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -121,8 +121,9 @@ terminal BETWEEN_HASHES: /#[^#]*#/;
 #### Rule Calls
 A terminal rule can implement other terminal rules. 
 ```
-terminal DOUBLE: INT '.' INT;
+terminal DOUBLE returns number: INT '.' INT;
 ```
+Note: it is easy to create conflict between terminal rules by using *terminal rule calls*. See [Data Type Rules](#data-type-rules) for further details.
 #### Alternatives
 It is possible to match several valid options. The terminal rule for white space can use alternatives as:
 ```
@@ -141,7 +142,7 @@ Fragments allow for sub-definition of terminal rules to be extracted. They are n
 ```
 terminal fragment CAPITAL_LETTER: ('A'..'Z');
 terminal fragment SMALL_LETTER: ('a'..'z');
-terminal WORD: (CAPITAL_LETTER|SMALL_LETTER)*;
+terminal NAME: CAPITAL_LETTER SMALL_LETTER+;
 ```
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
@@ -261,7 +262,7 @@ The parser rule `AbstractDefinition` will not create an object of type AbstractD
 ### Syntactic Predicates
 ## Hidden Terminal Symbols
 [QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. 
-## Data Types Rules
+## Data Type Rules
 ## Enum Rules
 [QUESTION] DOES LANGIUM SUPPORTS ENUM? PR#84 removed enum and added primitive instead
 ## Grammar Annotations

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -22,7 +22,7 @@ import 'path/to/an/other/langium/grammar';
 This will import **all grammar rules** from the imported grammar file. It is therefore crucial to ensure that there are no duplicate rules between the different grammar files.
 
 ## Terminal Rules
-The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a *terminal rule*, creating a atomic symbols. The names of terminal rules are conventionally written in upper case. 
+The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. A token is a sequence of one or many characters which is matched by a *terminal rule*, creating an atomic symbol. The names of terminal rules are conventionally written in upper case. 
 
 The Langium parser is created using [Chevrotain](https://github.com/chevrotain/chevrotain) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar. 
 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -216,7 +216,7 @@ There are three different ways to assign an expression (right side) to a propert
     Employee:
         'employee' name=ID (remote?='remote')?
     ```
-    Here the value of the property `remote` will be set to true if the keyword `remote` appears in the document.
+    Here the value of the property `remote` will be set to `true` if the keyword `remote` was successfully parsed as a part of the rule call.
 
 #### Cross-reference
 With Langium, you can declare *cross-references* directly in the grammar. *Cross-reference* allows to reference an object of a given type. The syntax is:

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -304,8 +304,29 @@ Addition:
 
 [TODO] Add part about syntax leading to unwanted elements in the tree.
 ### Syntactic Predicates
+Sometimes it is difficult to describe a problem without an ambiguous grammar. We can guide the parser through the grammar language by introducing *syntactic predicates*.
+In parser generator, a classical example of such ambiguous grammar is the *dangling else problem*. A simple `if-then else` statement is unambiguous:
+```
+if conditionA then statementA else statementB
+```
+A problem arises when we have to deal with nested if-then else statements:
+```
+if conditionA then if conditionB then statementA else statementB 
+```
+The `else` clause could either belong to the first or the second if statement.
 
+The parser needs to be guided in order to parse the conditional statement correctly. This is done by using *syntactic predicates* with the operator `=>` in front of the `else` keyword:
+```
+ConditionalStatement:
+    'if' '(' condition=BooleanExpression ')'
+    then=Statement
+    (=>'else' else=Statement)?
+``` 
+When the parser encounter the `=>` operator, it will look for the `else` keyword. If it is present, the parser will prioritize that part of the input without trying to match the same token sequence.
+
+In some cases you need to use a syntactic predicate in front of more complex rules. This can increase the lookahead and slow down the parser. Often times, looking only at the first token is enough to disambiguate between different inputs. This can be achieved by using the *first token set predicate* operator `->`.
 ## Data Type Rules
+
 ## Enum Rules
 [QUESTION] DOES LANGIUM SUPPORTS ENUM? PR#84 removed enum and added primitive instead
 ## Grammar Annotations

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -326,7 +326,7 @@ When the parser encounters the `=>` operator, it will look for the `else` keywor
 
 Using the *syntactic predicate operator* `=>` on complex rules with many tokens can increase the lookahead and therefore slow down the parser. Often times, disambiguation can be achieved by looking only at the first token. To do so, the *first token predicate* operator `->` can be used instead.
 ## Data Type Rules
-Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, are allowed to use hidden terminal rules, can avoid conflicts with terminal rules. 
+Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, and are allowed to use hidden terminal rules. Contrary to terminal rules, they cannot use *regular expressions* to match a stream of character and have to compose with terminal rules.
 
 The following example from the [domain model example]() avoids for the `QualifiedName` data type rule to conflict with the terminal rule `ID`.
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -122,16 +122,104 @@ Fragments allow for sub-definition of terminal rules to be extracted. They are n
 
 ```
 terminal fragment CAPITAL_LETTER: ('A'..'Z');
-termnial fragment SMALL_LETTER: ('a'..'z');
+terminal fragment SMALL_LETTER: ('a'..'z');
 terminal WORD: (CAPITAL_LETTER|SMALL_LETTER)*;
 ```
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
 ### Extended Backus-Naur Form Expressions
-#### Assignements
+Parser rules have access to a more restricted set of expressions compared to terminal rules. Parser and terminal rules share the following expressions:
+- Groups
+- Alternatives
+- Keywords
+- Rule calls
+
+Parser rules also have their own expressions as described below.
+#### Declaration
+A parser rule always starts with the name of the rule followed by an optional return type. If no return type is specified, the parser assumes that the object created has the type of the parser rule's name.
+```
+Person:
+    'person' name=ID;
+``` 
+In this example, the parser will create an object of type `Person`. This object will have a property `name` of type `ID` (defined by the terminal rule).
+
+[TODO] ADD SECTION ABOUT KEYWORDS
+#### Assignments
+There are three different ways to assign an expression (right side) to a property (left side).
+
+1. `=` is used for assigning **only one element** to a property
+    ```
+    Person:
+        'person' name=ID
+    ```
+    Here, the property `name` will only accept one expression of type `ID`
+2. `+=` is used to assign **multiple expressions** to a list property
+    ```
+    Paragraph:
+        'paragraph' (sentences+=STRING)+;
+    ```
+    [QUESTION] IS THIS DECLARATION VALID? OR SHOULD sentences BE ASSIGNED AN OTHER PARSER RULE INSTEAD OF A TERMINAL RULE?
+3. `?=` is used to assign a **value to a property of type boolean**. The value of the property of type `boolean` is set to `true` if the right part of the assignment is consume by the parser
+    ```
+    Employee:
+        'employee' name=ID (remote?='remote')?
+    ```
+    Here the value of the property `remote` will be set to true if the keyword `remote` appears in the declaration.
 #### Cross-reference
+[TODO] CHECK IN MORE DETAILS, I DON'T UNDERSTAND THE SYNTAX AND HOW IT'S IMPLEMENTED
 #### Unordered Groups
+By default, a parser rule has to be implemented in the exact order it is declared.
+```
+Person:
+    'person' name=ID age=INT
+```
+Here a `Person` object **needs** to first declare the property `name` then `age`
+``` 
+person Bob 25
+```
+will successfully create an object of type `Person` while
+```
+person 25 Bob
+```
+will throw an error.
+
+It is however possible to declared properties in an unordered fashion using the `&` operator
+```
+Person:
+    'person' name=ID & age=INT
+```
+will now allow `name` and `age` to be declared in any order.
+```
+person 25 Bob
+```
+will then successfully create an object of type `Person`.
+
+Cardinality (?,*,+ operators) also applies to unordered group. Please note that assignments with a cardinality of `+` or `*` have to appear continuously and cannot be interrupted by an other assignment and resumed later.
+```
+
+```
+[TODO] FIND GOOD EXAMPLE FOR CARDINALITY
 #### Simple Actions
+It is possible for a rule to return different types depending on declaration
+```
+FirstRule returns FirstType:
+    'firstKeyword' name=ID | SecondRule;
+
+SecondRule returns SecondType:
+    'secondKeyword' name=ID;
+```
+In the above example, we rely on a *rule call* to specify the return type. Actions allow to improve the readability of the grammar by explicitly defining the return type
+```
+RuleName returns FirstType:
+    'firstKeyword' name=ID | 'secondKeyword {SecondType} name=ID;
+```
+
+```
+PrimaryExpression returns Expression:
+	'(' Expression ')' |
+	{NumberLiteral} value=NUMBER |
+	{FunctionCall} func=[AbstractDefinition] ('(' args+=Expression (',' args+=Expression)* ')')?;
+```
 #### Unassigned Rule Calls
 #### Assigned Actions
 ### Syntactic Predicates
@@ -139,4 +227,3 @@ terminal WORD: (CAPITAL_LETTER|SMALL_LETTER)*;
 ## Data Types Rules
 ## Enum Rules
 ## Grammar Annotations
-

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -326,8 +326,12 @@ When the parser encounter the `=>` operator, it will look for the `else` keyword
 
 In some cases you need to use a syntactic predicate in front of more complex rules. This can increase the lookahead and slow down the parser. Often times, looking only at the first token is enough to disambiguate between different inputs. This can be achieved by using the *first token set predicate* operator `->`.
 ## Data Type Rules
+Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, are allowed to use hidden terminal rules, can avoid conflicts with terminal rules.
 
-## Enum Rules
-[QUESTION] DOES LANGIUM SUPPORTS ENUM? PR#84 removed enum and added primitive instead
-## Grammar Annotations
-[QUESTION] IS THAT IN THE LANGIUM GRAMMAR?
+The following example from the [domain model example]() avoids for the `QualifiedName` data type rule to conflict with the terminal rule `ID`.
+```
+QualifiedName returns string:
+    ID ('.' ID)*;
+```
+Data type rules need to specify a primitive return type.
+## Model

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -1,7 +1,7 @@
 ---
 title: "The Grammar Language"
 ---
-
+[TODO] INTRODUCTION TEXT ABOUT THE GRAMMAR LANGUAGE
 
 ## Language Declaration
 
@@ -23,13 +23,13 @@ Lexing transforms a stream of character into a stream of tokens. Tokens are a se
 terminal STRING: /"[^"]*"|'[^']*'/;
 ```
 
-Here, the token `STRING` will match a stream of character surrounded by double quotes `""` or single quotes `''`.
+Here, the token `STRING` will match a stream of character surrounded by double quotes or single quotes.
 
 **The order in which terminal rules are defined is critical** as the lexer will always return the first match.
 
 ### Return Types
 
-A terminal rule returns a Typescript type. If no return type is specified then the terminal rule will return a `string` by default. 
+A terminal rule always returns an instance of a Typescript type. If no return type is specified then the terminal rule will return a `string` by default. 
 
 ```
 terminal INT returns number: /[0-9]+/;
@@ -45,7 +45,7 @@ The available return types in Langium are:
 [QUESTION] WHAT ARE ALL THE AVAILABLE RETURN TYPES?
 
 ### Extended Backus-Naur Form Expressions
-Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions.
+Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions similar to the [Xtext](https://www.eclipse.org/Xtext/) notation.
 #### Cardinalities
 Four different cardinalities can be defined for any expression:
 1. exactly one (no operator)
@@ -116,7 +116,17 @@ Tokens can be put in sequence specifying the order they have to appear
 terminal FLIGHTNUMBER: ('A'..'Z')('A'..'Z')('0'..'9')('0'..'9')('0'..'9')('0'...'9')?;
 ```
 In this example, the token `FLIGHTNUMBER` must start with two capital letters and followed by three of four digits.
+
+### Terminal Fragments
+Fragments allow for sub-definition of terminal rules to be extracted. They are not consumed by the lexer and have to be consumed by other terminal rules.
+
+```
+terminal fragment CAPITAL_LETTER: ('A'..'Z');
+termnial fragment SMALL_LETTER: ('a'..'z');
+terminal WORD: (CAPITAL_LETTER|SMALL_LETTER)*;
+```
 ## Parser Rules
+[TODO] INTRODUCTION ABOUT PARSER RULES
 ### Extended Backus-Naur Form Expressions
 #### Assignements
 #### Cross-reference

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -116,7 +116,7 @@ Tokens can be put in sequence specifying the order they have to appear
 ```
 terminal FLIGHT_NUMBER: ('A'..'Z')('A'..'Z')('0'..'9')('0'..'9')('0'..'9')('0'...'9')?;
 ```
-In this example, the token `FLIGHT_NUMBER` **must** start with two capital letters and followed by three of four digits.
+In this example, the token `FLIGHT_NUMBER` **must** start with two capital letters and followed by three or four digits.
 
 ### Terminal Fragments
 Fragments allow for sub-definition of terminal rules to be extracted. They are not consumed by the lexer and have to be consumed by other terminal rules.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -131,7 +131,7 @@ terminal NAME: CAPITAL_LETTER SMALL_LETTER+;
 In this example, the lexer will not transform a single capital or small letter into a valid token but will match a sequence of one capital letter followed by one or many small letters.
 
 ### Hidden Terminal Rules
-The parser tries to match every character in the document to a terminal rules. It is therefore necessary to specify which characters or sequence of characters need to be ignored during parsing. Generally, you would want to ignore whitespaces and comments. This is achieved by adding the keyword `hidden` in front of the keyword `terminal` when defining a *terminal rule*. These *hidden terminal rules* are global and will be valid for all parser rules in the document.
+The lexer tries to match every character in the document to a terminal rule or a keyword. It is therefore necessary to specify which characters or sequence of characters need to be ignored during lexing and parsing. Generally, you would want to ignore whitespaces and comments. This is achieved by adding the keyword `hidden` in front of the keyword `terminal` when defining a *terminal rule*. These *hidden terminal rules* are global and will be valid for all parser rules in the document.
 ```
 hidden terminal WS: /\s+/;
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -1,0 +1,32 @@
+---
+title: "The Grammar Language"
+---
+
+## Language Declaration
+
+## Terminal Rules
+### Return Types
+### Extended Backus-Naur Form Expressions
+#### Keywords
+#### Character Range
+#### Wildcard
+#### Until Token
+#### Negated Token
+#### Rule Calls
+#### Alternatives
+#### Groups
+
+## Parser Rules
+### Extended Backus-Naur Form Expressions
+#### Assignements
+#### Cross-reference
+#### Unordered Groups
+#### Simple Actions
+#### Unassigned Rule Calls
+#### Assigned Actions
+### Syntactic Predicates
+## Hidden Terminal Symbols
+## Data Types Rules
+## Enum Rules
+## Grammar Annotations
+

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -82,22 +82,24 @@ is equivalent to the regular expression:
 terminal INT returns number: /[0-9]+/;
 ```
 
-Here, INT is matched to one or more characters (by using the operand `+`, which defines a cardinality of 'one or many') between `0` and `9` (inclusive on both ends).
+Here, `INT` is matched to one or more characters (by using the operand `+`, which defines a cardinality of 'one or many') between `0` and `9` (inclusive on both ends).
 
 #### Wildcard
 The operator `.` is used to match any character and is similar in regular expression.
+```
+terminal HASHTAG: '#'.+;
+```
+In this example, the terminal rule `HASHTAG` matches a sequence of character starting with `#` followed by one or many (cardinality +) characters.
 
-[TODO] FIND GOOD EXAMPLE WITH THE WILDCARD USED
-
+Equivalent in regular expression:
+```
+terminal HASHTAG: /#.+/;
+```
 #### Until Token
-The operator `->` indicates that all characters should be consumed from one token until a specific token occurs. For example, the terminal rule for multi-line comment can be implemented as:
+The operator `->` indicates that all characters should be consumed from the left token *until* the right token occurs. For example, the terminal rule for multi-line comment can be implemented as:
 
 ```
 terminal ML_COMMENT: '/*' -> '*/';
-```
-Regular expression equivalent:
-```
-terminal ML_COMMENT: /\/\*(.*?)\*\//;
 ```
 #### Negated Token
 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -221,9 +221,19 @@ PrimaryExpression returns Expression:
 	{FunctionCall} func=[AbstractDefinition] ('(' args+=Expression (',' args+=Expression)* ')')?;
 ```
 #### Unassigned Rule Calls
+Parser rules do not necessarily need to return an object, they can also refer to other parser rules which in turn will be responsible for returning the object.
+For example, in the Arithmetics example:
+```
+AbstractDefinition:
+	Definition | DeclaredParameter;
+```
+The parser rule `AbstractDefinition` will not create an object of type AbstractDefinition. Instead, it calls either the `Definition` or `DeclaredParameter` parser rule which will create an object of type Definition or DeclaredParameter respectively. 
 #### Assigned Actions
 ### Syntactic Predicates
 ## Hidden Terminal Symbols
+[QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. 
 ## Data Types Rules
 ## Enum Rules
+[QUESTION] DOES LANGIUM SUPPORTS ENUM? PR#84 removed enum and added primitive instead
 ## Grammar Annotations
+[QUESTION] IS THAT IN THE LANGIUM GRAMMAR?

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -56,13 +56,17 @@ The available return types in Langium are:
 [QUESTION] What are the available return types?
 
 ### Extended Backus-Naur Form Expressions
-Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions similar to the [Xtext](https://www.eclipse.org/Xtext/) notation.
+Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions similar to the [Xtext](https://www.eclipse.org/Xtext/) notation. In this section, we describe which EBNF expressions are supported in Langium and their equivalent in *Javascript Regular Expressions* where possible.
 #### Cardinalities
-Four different cardinalities can be defined for any expression:
+A cardinality defines the number of elements in a given set. Four different cardinalities can be defined for any expression:
 1. exactly one (no operator)
 2. zero or one (operator ?)
 3. zero or many (operator *)
 4. one or many (operator +)
+
+[QUESTION]Is it possible with EBNF to have a "range cardinality" similar to the {x,y} in regex?
+
+[QUESTION]Should we add examples of cardinalities here?
 #### Keywords
 [QUESTION] SHOULD THIS PART BE ONLY ABOUT THE RESERVED KEYWORDS? KEYWORDS USED FOR TERMINAL RULES ONLY?
 Keywords are terminal rules used by the Langium grammar itself. 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -86,7 +86,10 @@ The operator `->` indicates that all characters should be consumed from the left
 ```
 terminal ML_COMMENT: '/*' -> '*/';
 ```
-There is no direct equivalent in regular expression for the until token.
+Langium will transform the until token into the regular expression `[\s\S]*?` which matches any character non-greedily:
+```
+terminal ML_COMMENT: /\/*[\s\S]*?\*\//;
+``` 
 
 #### Negated Token
 It is possible to negate all tokens using the operator `!`, in regular expression the operator `^` is used for negation.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -35,7 +35,7 @@ Here, the token `ID` will match a stream of characters starting with the charact
 **The order in which terminal rules are defined is critical** as the lexer will always return the first match.
 
 ### Return Types
-A terminal rule returns an instance of a `Typescript primitive type`. If no return type is specified then the terminal rule will return a `string` by default. 
+A terminal rule returns an instance of a _TypeScript primitive type_. If no return type is specified, the terminal rule will return a `string` by default. 
 ```
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal INT returns number: /[0-9]+/;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -147,15 +147,18 @@ terminal NAME: CAPITAL_LETTER SMALL_LETTER+;
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
 ### Keywords
-[QUESTION] SHOULD THIS PART BE ONLY ABOUT THE RESERVED KEYWORDS? KEYWORDS USED FOR TERMINAL RULES ONLY?
-Keywords are terminal rules used by the Langium grammar itself. 
-- `grammar`
-- `import`
-- `entry`
-- `hidden`
-- `fragment`
+A parser rule that creates an object starts with a keyword. The keyword must match the regular expression `/\^?[_a-zA-Z][\w_]*/` and appear in the grammar file between single quotes.
 
-[QUESTION] WHAT ARE ALL THE KEYWORDS IN THE LANGIUM GRAMMAR AND SHOULD THEY BE EXPLAINED HERE OR IN THEIR RESPECTIVE SECTION?
+```
+Person:
+    'person' name=ID;
+```
+In this example, the keyword `person` indicates to the parser that an object of type `Person` must be parsed. A parser rule can have many keywords:
+```
+Person:
+    'person' name=ID 'age' age=INT;
+```
+[QUESTION] Are there keywords that are reserved for the Langium grammar ('grammar', 'terminal', 'fragment' ...)? Or can a rule "override" the use of those keywords?
 ### Extended Backus-Naur Form Expressions
 Parser rules have access to a more restricted set of expressions compared to terminal rules. Parser and terminal rules share the following expressions:
 - Groups

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -300,7 +300,7 @@ Expression:
 Addition:
     Expression ('+' Expression)*;
 ```
-[NOTE] Contrary to the Xtext doc, I had to had `value=` for the code to compile, otherwise is throws a `RangeError: Maximum call stack size exceeded`. Any idea why?
+[NOTE] Contrary to the Xtext doc, I had to add `value=` for the code to compile, otherwise is throws a `RangeError: Maximum call stack size exceeded`. Any idea why?
 
 [TODO] Add part about syntax leading to unwanted elements in the tree.
 ### Syntactic Predicates
@@ -322,11 +322,11 @@ ConditionalStatement:
     then=Statement
     (=>'else' else=Statement)?
 ``` 
-When the parser encounter the `=>` operator, it will look for the `else` keyword. If it is present, the parser will prioritize that part of the input without trying to match the same token sequence.
+When the parser encounters the `=>` operator, it will look for the `else` keyword. If it is present, the parser will prioritize that part of the input without trying to match the same token sequence.
 
-In some cases you need to use a syntactic predicate in front of more complex rules. This can increase the lookahead and slow down the parser. Often times, looking only at the first token is enough to disambiguate between different inputs. This can be achieved by using the *first token set predicate* operator `->`.
+Using the *syntactic predicate operator* `=>` on complex rules with many tokens can increase the lookahead and therefore slow down the parser. Often times, disambiguation can be achieved by looking only at the first token. To do so, the *first token predicate* operator `->` can be used instead.
 ## Data Type Rules
-Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, are allowed to use hidden terminal rules, can avoid conflicts with terminal rules.
+Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, are allowed to use hidden terminal rules, can avoid conflicts with terminal rules. 
 
 The following example from the [domain model example]() avoids for the `QualifiedName` data type rule to conflict with the terminal rule `ID`.
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -24,13 +24,14 @@ This will import **all grammar rules** from the imported grammar file. It is the
 
 [QUESTION] Is the above sentence true? Or is there a way to import only part of a grammar?
 ## Terminal Rules
-Lexing transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a specific *terminal rule*. The names of terminal rules are conventionally written in upper case. The matching of terminal rules follows *regular expressions*.
+The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a *terminal rule*. The names of terminal rules are conventionally written in upper case. 
+The Langium parser is created using [Chevrotain](https://chevrotain.io/docs/) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar.
 
 ```
-terminal STRING: /"[^"]*"|'[^']*'/;
+terminal ID: /[_a-zA-Z][\w_]*/;
 ```
 
-Here, the token `STRING` will match a stream of character surrounded by double quotes or single quotes.
+Here, the token `ID` will match a stream of character starting with the character '\_', a small letter, or a capital letter followed by sequence of zero or many ([cardinality](#cardinalities) *) alphanumeric characters ('\w') or '\_'.
 
 **The order in which terminal rules are defined is critical** as the lexer will always return the first match.
 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -146,19 +146,7 @@ terminal NAME: CAPITAL_LETTER SMALL_LETTER+;
 ```
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
-### Keywords
-A parser rule that creates an object starts with a keyword. The keyword must match the regular expression `/\^?[_a-zA-Z][\w_]*/` and appear in the grammar file between single quotes.
 
-```
-Person:
-    'person' name=ID;
-```
-In this example, the keyword `person` indicates to the parser that an object of type `Person` must be parsed. A parser rule can have many keywords:
-```
-Person:
-    'person' name=ID 'age' age=INT;
-```
-[QUESTION] Are there keywords that are reserved for the Langium grammar ('grammar', 'terminal', 'fragment' ...)? Or can a rule "override" the use of those keywords?
 ### Extended Backus-Naur Form Expressions
 Parser rules have access to a more restricted set of EBNF expressions compared to terminal rules. Parser and terminal rules share the following expressions:
 - Groups
@@ -175,7 +163,19 @@ Person:
 ``` 
 In this example, the parser will create an object of type `Person`. This object will have a property `name` which value and type must match the terminal rule `ID` (i.e. the property `name` is of type `string`).
 
-[TODO] ADD SECTION ABOUT KEYWORDS
+#### Keywords
+A parser rule that creates an object starts with a keyword. The keyword must match the regular expression `/\^?[_a-zA-Z][\w_]*/` and appear in the grammar file between single quotes.
+
+```
+Person:
+    'person' name=ID;
+```
+In this example, the keyword `person` indicates to the parser that an object of type `Person` must be parsed. A parser rule can have many keywords:
+```
+Person:
+    'person' name=ID 'age' age=INT;
+```
+[QUESTION] Are there keywords that are reserved for the Langium grammar ('grammar', 'terminal', 'fragment' ...)? Or can a rule "override" the use of those keywords?
 #### Assignments
 There are three different ways to assign an expression (right side) to a property (left side).
 
@@ -184,7 +184,7 @@ There are three different ways to assign an expression (right side) to a propert
     Person:
         'person' name=ID
     ```
-    Here, the property `name` will only accept one expression matching the terminal rule `ID`
+    Here, the property `name` will only accept one expression matching the terminal rule `ID`.
 2. `+=` is used to assign **multiple expressions** to a list property
     ```
     Paragraph:

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -102,7 +102,7 @@ terminal BETWEEN_HASHES: /#[^#]*#/;
 ```
 
 #### Rule Calls
-A terminal rule can implement other terminal rules. 
+A terminal rule can include other terminal rules in its definition.
 ```
 terminal DOUBLE returns number: INT '.' INT;
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -6,10 +6,10 @@ The grammar language describes the syntax and structure of your language. The [L
 In the following, we describe the Langium syntax and document structure.
 ## Language Declaration
 
-A Langium grammar file always starts with a header which declares the name of the language. For example, a language named `LanguageName` would be declared with:
+A Langium grammar file always starts with a header which declares the name of the language. For example, a language named `MyLanguage` would be declared with:
 
 ```
-grammar LanguageName
+grammar MyLanguage
 ```
 
 Every grammar file has a `.langium` extension and needs to be referenced in `langium-config.json`. If you used the `langium-generator` to start your project then your language was automatically referenced in `langium-config.json`.
@@ -25,7 +25,7 @@ This will import **all grammar rules** from the imported grammar file. It is the
 [QUESTION] Is the above sentence true? Or is there a way to import only part of a grammar?
 ## Terminal Rules
 The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a *terminal rule*. The names of terminal rules are conventionally written in upper case. 
-The Langium parser is created using [Chevrotain](https://chevrotain.io/docs/) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar.
+The Langium parser is created using [Chevrotain](https://chevrotain.io/docs/) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar. The declaration of a terminal rule starts with the [keyword](#keywords) `terminal`:
 
 ```
 terminal ID: /[_a-zA-Z][\w_]*/;
@@ -67,17 +67,6 @@ A cardinality defines the number of elements in a given set. Four different card
 [QUESTION]Is it possible with EBNF to have a "range cardinality" similar to the {x,y} in regex?
 
 [QUESTION]Should we add examples of cardinalities here?
-#### Keywords
-[QUESTION] SHOULD THIS PART BE ONLY ABOUT THE RESERVED KEYWORDS? KEYWORDS USED FOR TERMINAL RULES ONLY?
-Keywords are terminal rules used by the Langium grammar itself. 
-- `grammar`
-- `import`
-- `entry`
-- `hidden`
-- `fragment`
-
-[QUESTION] WHAT ARE ALL THE KEYWORDS IN THE LANGIUM GRAMMAR AND SHOULD THEY BE EXPLAINED HERE OR IN THEIR RESPECTIVE SECTION?
-
 #### Character Range
 The operator `..` is used to declare a character range. It is equivalent to the operator `-`in regular expression.
 
@@ -142,6 +131,16 @@ terminal WORD: (CAPITAL_LETTER|SMALL_LETTER)*;
 ```
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
+### Keywords
+[QUESTION] SHOULD THIS PART BE ONLY ABOUT THE RESERVED KEYWORDS? KEYWORDS USED FOR TERMINAL RULES ONLY?
+Keywords are terminal rules used by the Langium grammar itself. 
+- `grammar`
+- `import`
+- `entry`
+- `hidden`
+- `fragment`
+
+[QUESTION] WHAT ARE ALL THE KEYWORDS IN THE LANGIUM GRAMMAR AND SHOULD THEY BE EXPLAINED HERE OR IN THEIR RESPECTIVE SECTION?
 ### Extended Backus-Naur Form Expressions
 Parser rules have access to a more restricted set of expressions compared to terminal rules. Parser and terminal rules share the following expressions:
 - Groups

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -317,7 +317,7 @@ Addition:
 [NOTE] I left out the part regarding `tree rewrite actions` as I think it could be part of a more advanced documentation part on the AST/CST. I can add it if we think it belongs here.
 
 ## Data Type Rules
-Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, and are allowed to use hidden terminal rules. Contrary to terminal rules, they cannot use *regular expressions* to match a stream of character and have to compose with terminal rules.
+Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, and are allowed to use hidden terminal rules. Contrary to terminal rules, they cannot use *regular expressions* to match a stream of character and have to be composed of terminal rules and keywords.
 
 The following example from the [domain model example]() avoids for the `QualifiedName` data type rule to conflict with the terminal rule `ID`.
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -98,14 +98,24 @@ terminal HASHTAG: /#.+/;
 #### Until Token
 The operator `->` indicates that all characters should be consumed from the left token *until* the right token occurs. For example, the terminal rule for multi-line comment can be implemented as:
 
+[QUESTION] Is the matching greedy or lazy in this case? 
+
 ```
 terminal ML_COMMENT: '/*' -> '*/';
 ```
+
+There is no equivalent in regular expression for the until token.
+
+[QUESTION]At least no equivalent in regex I'm aware of or could find with a quick search...
 #### Negated Token
 
-It is possible to negate all tokens using the operator `!`
+It is possible to negate all tokens using the operator `!`, in regular expression the operator `^` is used for negation.
 ```
-terminal ML_COMMENT: '/*' (!'*/')* '/*'; 
+terminal BETWEEN_HASHES:'#' (!'#')* '#';
+```
+In regular expression:
+```
+terminal BETWEEN_HASHES: /#[^#]*#/;
 ```
 
 #### Rule Calls

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -209,7 +209,7 @@ Person:
 Greeting:
     'Hello' person=[Person:ID] '!';
 ```
-The `Person` in square brackets does not refer to a parser rule `Person` but instead refers to an object of type `Person`. It will successfully parse a document like:
+The `Person` in square brackets does not refer to the parser rule `Person` but instead refers to an object of type `Person`. It will successfully parse a document like:
 ```
 person Bob
 Hello Bob !
@@ -219,26 +219,28 @@ but will fail to parse:
 person Bob
 Hello Sara !
 ```
-because a `Person` object with the ID of 'Sara' has not been instantiated.
+because a `Person` object with the ID of 'Sara' has not been instantiated even though 'Sara' is a valid `ID`.
 
-[QUESTION] I failed to reference an instance with using something else than ID. Reading teh Xtext doc and the langium-grammar it seems like it is possible but I couldn't figure out how...
+[QUESTION] I failed to reference an instance with using something else than ID. Reading the Xtext doc and the langium-grammar it seems like it is possible but I couldn't figure out how...
 #### Unordered Groups
+[NOTE] Unordered group are currently unsupported but seems like it's being worked on. Let's consider the following as something that could be added when the feature is available.
+
 By default, a parser rule has to be implemented in the exact order it is declared.
 ```
 Person:
     'person' name=ID age=INT
 ```
-Here a `Person` object **needs** to first declare the property `name` then `age`
-``` 
+Here a `Person` object **needs** to first declare the property `name` then `age`.
+```
 person Bob 25
 ```
-will successfully create an object of type `Person` while
+will successfully be parsed to an object of type `Person` while
 ```
 person 25 Bob
 ```
 will throw an error.
 
-It is however possible to declared properties in an unordered fashion using the `&` operator
+However, it is possible to declare a group of properties in an unordered fashion using the `&` operator
 ```
 Person:
     'person' name=ID & age=INT
@@ -250,34 +252,24 @@ person 25 Bob
 will then successfully create an object of type `Person`.
 
 Cardinality (?,*,+ operators) also applies to unordered group. Please note that assignments with a cardinality of `+` or `*` have to appear continuously and cannot be interrupted by an other assignment and resumed later.
-```
-
-```
-[TODO] FIND GOOD EXAMPLE FOR CARDINALITY
 #### Simple Actions
 It is possible for a rule to return different types depending on declaration
 ```
-FirstRule returns FirstType:
-    'firstKeyword' name=ID | SecondRule;
+RuleOne returns TypeOne:
+    'keywordOne' name=ID | RuleTwo;
 
-SecondRule returns SecondType:
-    'secondKeyword' name=ID;
+RuleTwo returns TypeTwo:
+    'keywordTwo' name=ID;
 ```
-In the above example, we rely on a *rule call* to specify the return type. Actions allow to improve the readability of the grammar by explicitly defining the return type
+In the above example, we rely on a *rule call* to specify the return type. With more complex rules, the readability will be highly degraded. *Actions* allow to improve the readability of the grammar by explicitly defining the return type
 ```
 RuleName returns FirstType:
-    'firstKeyword' name=ID | 'secondKeyword {SecondType} name=ID;
+    'firstKeyword' name=ID | 'secondKeyword' {SecondType} name=ID;
 ```
-
-```
-PrimaryExpression returns Expression:
-	'(' Expression ')' |
-	{NumberLiteral} value=NUMBER |
-	{FunctionCall} func=[AbstractDefinition] ('(' args+=Expression (',' args+=Expression)* ')')?;
-```
+We improved the readability by explicitly declaring the return type inside curly brackets.
 #### Unassigned Rule Calls
 Parser rules do not necessarily need to return an object, they can also refer to other parser rules which in turn will be responsible for returning the object.
-For example, in the Arithmetics example:
+For example, in the [Arithmetics example]():
 ```
 AbstractDefinition:
 	Definition | DeclaredParameter;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -30,7 +30,7 @@ The declaration of a terminal rule starts with the keyword `terminal`:
 ```
 terminal ID: /[_a-zA-Z][\w_]*/;
 ```
-Here, the token `ID` will match a stream of character starting with the character '\_', a small letter, or a capital letter followed by sequence of zero or many ([cardinality](#cardinalities) *) alphanumeric characters ('\w') or '\_'.
+Here, the token `ID` will match a stream of characters starting with the character '\_', a small letter, or a capital letter followed by a sequence of zero or many ([cardinality](#cardinalities) *) alphanumeric characters ('\w') or '\_'.
 
 **The order in which terminal rules are defined is critical** as the lexer will always return the first match.
 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -334,4 +334,11 @@ QualifiedName returns string:
     ID ('.' ID)*;
 ```
 Data type rules need to specify a primitive return type.
-## Model
+## The Model Object
+ The parser will create objects for valid *parser rules* which will be stored in a *model object*. The model object contains arrays of the different objects group by type. In Langium, you define which parsed objects need to be exported into the *model object* by defining a special parser rule starting with the keyword `entry`.
+
+ ```
+ entry Model:
+    (persons+=Person | greetings+=Greeting)*;
+ ```
+The *model object* of type `Model` will have two properties:  an array of objects of type `Person` and a second one of objects of types `Greeting`.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -22,7 +22,7 @@ import 'path/to/an/other/langium/grammar';
 This will import **all grammar rules** from the imported grammar file. It is therefore crucial to ensure that there are no duplicate rules between the different grammar files.
 
 ## Terminal Rules
-The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a *terminal rule*. The names of terminal rules are conventionally written in upper case. 
+The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a *terminal rule*, creating a atomic symbols. The names of terminal rules are conventionally written in upper case. 
 
 The Langium parser is created using [Chevrotain](https://github.com/chevrotain/chevrotain) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar. 
 
@@ -136,7 +136,7 @@ hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;
 ```
 
 ## Parser Rules
-[TODO] INTRODUCTION ABOUT PARSER RULES
+While [terminal rules](#terminal-rules) indicate to the lexer what sequence of characters are valid tokens, *parser rules* indicate to the parser what sequence of tokens are valid. Parser rules lay the structure of objects to be created by the parser and result in the creation of the *abstract syntax tree* which represents the syntactic structure of your language. In Langium, parser rules are also responsible for defining the type of objects to be parsed.
 
 ### Extended Backus-Naur Form Expressions
 Parser rules have access to a more restricted set of EBNF expressions compared to terminal rules. Parser and terminal rules share the following expressions:

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -106,7 +106,7 @@ A terminal rule can implement other terminal rules.
 ```
 terminal DOUBLE returns number: INT '.' INT;
 ```
-Note that it is easy to create conflict between terminal rules by using *terminal rule calls*. See [Data Type Rules](#data-type-rules) for further details.
+Note that it is easy to create conflicts between terminal rules when using *terminal rule calls*. See [Data Type Rules](#data-type-rules) for further details.
 
 #### Alternatives
 It is possible to match several valid options. The terminal rule `STRING` can use alternatives to match a sequence of characters between double quotes `""` or single quotes `''`:

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -6,13 +6,13 @@ The grammar language describes the syntax and structure of your language. The [L
 In the following, we describe the Langium syntax and document structure.
 ## Language Declaration
 
-A Langium grammar file starts with a header which declares the name of the language
+A Langium grammar file always starts with a header which declares the name of the language
 
 ```
 grammar LanguageName
 ```
 
-Every grammar file have the file extension `.langium` and needs to be referenced in `langium-config.json`
+Every grammar file has a `.langium` extension and needs to be referenced in `langium-config.json`. If you used the `langium-generator` to start your project then your language was automatically referenced in `langium-config.json`.
 
 [TODO] ADD IMPORT OF OTHER GRAMMAR FILES
 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -160,7 +160,7 @@ Person:
 ```
 [QUESTION] Are there keywords that are reserved for the Langium grammar ('grammar', 'terminal', 'fragment' ...)? Or can a rule "override" the use of those keywords?
 ### Extended Backus-Naur Form Expressions
-Parser rules have access to a more restricted set of expressions compared to terminal rules. Parser and terminal rules share the following expressions:
+Parser rules have access to a more restricted set of EBNF expressions compared to terminal rules. Parser and terminal rules share the following expressions:
 - Groups
 - Alternatives
 - Keywords
@@ -173,7 +173,7 @@ A parser rule always starts with the name of the rule followed by an optional re
 Person:
     'person' name=ID;
 ``` 
-In this example, the parser will create an object of type `Person`. This object will have a property `name` of type `ID` (defined by the terminal rule).
+In this example, the parser will create an object of type `Person`. This object will have a property `name` which value and type must match the terminal rule `ID` (i.e. the property `name` is of type `string`).
 
 [TODO] ADD SECTION ABOUT KEYWORDS
 #### Assignments
@@ -184,7 +184,7 @@ There are three different ways to assign an expression (right side) to a propert
     Person:
         'person' name=ID
     ```
-    Here, the property `name` will only accept one expression of type `ID`
+    Here, the property `name` will only accept one expression matching the terminal rule `ID`
 2. `+=` is used to assign **multiple expressions** to a list property
     ```
     Paragraph:

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -316,29 +316,6 @@ Addition:
 
 [NOTE] I left out the part regarding `tree rewrite actions` as I think it could be part of a more advanced documentation part on the AST/CST. I can add it if we think it belongs here.
 
-### Syntactic Predicates
-Sometimes it is difficult to describe a problem without an ambiguous grammar. We can guide the parser through the grammar language by introducing *syntactic predicates*.
-In parser generator, a classical example of such ambiguous grammar is the *dangling else problem*. A simple `if-then else` statement is unambiguous:
-```
-if conditionA then statementA else statementB
-```
-A problem arises when we have to deal with nested if-then else statements:
-```
-if conditionA then if conditionB then statementA else statementB 
-```
-The `else` clause could either belong to the first or the second if statement.
-
-The parser needs to be guided in order to parse the conditional statement correctly. This is done by using *syntactic predicates* with the operator `=>` in front of the `else` keyword:
-```
-ConditionalStatement:
-    'if' '(' condition=BooleanExpression ')'
-    then=Statement
-    (=>'else' else=Statement)?
-``` 
-When the parser encounters the `=>` operator, it will look for the `else` keyword. If it is present, the parser will prioritize that part of the input without trying to match the same token sequence.
-
-Using the *syntactic predicate operator* `=>` on complex rules with many tokens can increase the lookahead and therefore slow down the parser. Often times, disambiguation can be achieved by looking only at the first token. To do so, the *first token predicate* operator `->` can be used instead.
-
 ## Data Type Rules
 Data type rules are similar to terminal rules as they match a sequence of characters. However, they are parser rules and therefore are context-dependent, and are allowed to use hidden terminal rules. Contrary to terminal rules, they cannot use *regular expressions* to match a stream of character and have to compose with terminal rules.
 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -269,7 +269,7 @@ RuleName returns FirstType:
 We improved the readability by explicitly declaring the return type inside curly brackets.
 #### Unassigned Rule Calls
 Parser rules do not necessarily need to return an object, they can also refer to other parser rules which in turn will be responsible for returning the object.
-For example, in the [Arithmetics example]():
+For example, in the [Arithmetics example](https://github.com/langium/langium/blob/main/examples/arithmetics/src/language-server/arithmetics.langium):
 ```
 AbstractDefinition:
 	Definition | DeclaredParameter;
@@ -279,7 +279,7 @@ The parser rule `AbstractDefinition` will not create an object of type AbstractD
 
 ### Syntactic Predicates
 ## Hidden Terminal Symbols
-[QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. 
+[QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. it doesn't work so needs to be declared as a 'global' token
 ## Data Type Rules
 ## Enum Rules
 [QUESTION] DOES LANGIUM SUPPORTS ENUM? PR#84 removed enum and added primitive instead

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -223,7 +223,7 @@ With Langium, you can declare *cross-references* directly in the grammar. A *cro
 ```
 property=[Type:TOKEN]
 ```
-The `property` will be a reference to an object of type `Type` identified by the token `TOKEN`. If the `TOKEN` is omitted, the parser assumes that it is matching the terminal rule `ID`.
+The `property` will be a reference to an object of type `Type` identified by the token `TOKEN`. If the `TOKEN` is omitted, the parser will use the terminal or data type rule associated with the `name` assignment of the `Type` rule.
 ```
 Person:
     'person' name=ID;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -5,47 +5,41 @@ The grammar language describes the syntax and structure of your language. The [L
 
 In the following, we describe the Langium syntax and document structure.
 ## Language Declaration
-
-A Langium grammar file always starts with a header which declares the name of the language. For example, a language named `MyLanguage` would be declared with:
+A Langium grammar file always starts with a header which declares the name of the language.  For example, a language named `MyLanguage` would be declared with:
 
 ```
 grammar MyLanguage
 ```
+Note that this is not the case for grammar files that are meant to be reused by other grammar files. In this case, the `grammar` declaration can be omitted.
 
 Every grammar file has a `.langium` extension and needs to be referenced in `langium-config.json`. If you used the `langium-generator` to start your project then your language was automatically referenced in `langium-config.json`.
 
-### Import other grammar languages
-It is possible to reuse grammar rules from other `.langium` files by importing them into your grammar file.
-
+### Import of other grammar languages
+It is possible to reuse grammar rules from other `.langium` files by importing them into your own grammar file.
 ```
 import 'path/to/an/other/langium/grammar';
 ```
 This will import **all grammar rules** from the imported grammar file. It is therefore crucial to ensure that there are no duplicate rules between the different grammar files.
 
-[QUESTION] Is the above sentence true? Or is there a way to import only part of a grammar?
 ## Terminal Rules
 The first step in parsing your language, *lexing*, transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a *terminal rule*. The names of terminal rules are conventionally written in upper case. 
-The Langium parser is created using [Chevrotain](https://chevrotain.io/docs/) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar. The declaration of a terminal rule starts with the [keyword](#keywords) `terminal`:
 
+The Langium parser is created using [Chevrotain](https://chevrotain.io/docs/) which has a built-in lexer based on *Javascript Regular Expressions*. However, Langium allows the use of [Extended Backus-Naur Form Expressions](#extended-backus-naur-form-expressions) and both expressions can be used conjointly in the same grammar. 
+
+The declaration of a terminal rule starts with the keyword `terminal`:
 ```
 terminal ID: /[_a-zA-Z][\w_]*/;
 ```
-
 Here, the token `ID` will match a stream of character starting with the character '\_', a small letter, or a capital letter followed by sequence of zero or many ([cardinality](#cardinalities) *) alphanumeric characters ('\w') or '\_'.
 
 **The order in which terminal rules are defined is critical** as the lexer will always return the first match.
 
 ### Return Types
-
-A terminal rule always returns an instance of a `Typescript primitive type`. If no return type is specified then the terminal rule will return a `string` by default. 
-
-[QUESTION] Is the return type always a primitive type?
-
+A terminal rule returns an instance of a `Typescript primitive type`. If no return type is specified then the terminal rule will return a `string` by default. 
 ```
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal INT returns number: /[0-9]+/;
 ```
-
 Here, the terminal rule `ID` will return an instance of `string` while the terminal rule `INT` will return an instance of `number`.
 
 The available return types in Langium are: 
@@ -53,43 +47,35 @@ The available return types in Langium are:
 - `number`
 - `boolean`
 - `bigint`
-[QUESTION] What are the available return types?
+- `Date`
 
 ### Extended Backus-Naur Form Expressions
 Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions similar to the [Xtext](https://www.eclipse.org/Xtext/) notation. In this section, we describe which EBNF expressions are supported in Langium and their equivalent in *Javascript Regular Expressions* where possible.
+
 #### Cardinalities
 A cardinality defines the number of elements in a given set. Four different cardinalities can be defined for any expression:
 1. exactly one (no operator)
-2. zero or one (operator ?)
-3. zero or many (operator *)
-4. one or many (operator +)
+2. zero or one (operator `?`)
+3. zero or many (operator `*`)
+4. one or many (operator `+`)
 
-[QUESTION]Is it possible with EBNF to have a "range cardinality" similar to the {x,y} in regex?
-
-[QUESTION]Should we add examples of cardinalities here?
 #### Character Range
-The operator `..` is used to declare a character range. It is equivalent to the operator `-`in regular expression. It matches any character in between the left character and the right character (inclusive on both ends) depending on their UTF-16 code.
-
-[QUESTION] I could find where in the langium code base we parse this range. I assumed it would be based on String.prototype.charCodeAt() or something similar. Please correct if I'm wrong.
-
+The operator `..` is used to declare a character range. It is equivalent to the operator `-` in regular expression. It matches any character in between the left character and the right character (inclusive on both ends).
 ```
 terminal INT returns number: ('0'..'9')+;
 ```
-
 is equivalent to the regular expression:
-
 ```
 terminal INT returns number: /[0-9]+/;
 ```
-
-Here, `INT` is matched to one or more characters (by using the operand `+`, which defines a cardinality of 'one or many') between `0` and `9` (inclusive on both ends).
+Here, `INT` is matched to one or more characters (by using the operand `+`, which defines a [cardinality](#cardinalities) of 'one or many') between `0` and `9` (inclusive on both ends).
 
 #### Wildcard
 The operator `.` is used to match any character and is similar in regular expression.
 ```
 terminal HASHTAG: '#'.+;
 ```
-In this example, the terminal rule `HASHTAG` matches a sequence of character starting with `#` followed by one or many (cardinality +) characters.
+In this example, the terminal rule `HASHTAG` matches a sequence of character starting with `#` followed by one or many ([cardinality](#cardinalities) +) characters.
 
 Equivalent in regular expression:
 ```
@@ -97,18 +83,12 @@ terminal HASHTAG: /#.+/;
 ```
 #### Until Token
 The operator `->` indicates that all characters should be consumed from the left token *until* the right token occurs. For example, the terminal rule for multi-line comment can be implemented as:
-
-[QUESTION] Is the matching greedy or lazy in this case? 
-
 ```
 terminal ML_COMMENT: '/*' -> '*/';
 ```
+There is no direct equivalent in regular expression for the until token.
 
-There is no equivalent in regular expression for the until token.
-
-[QUESTION]At least no equivalent in regex I'm aware of or could find with a quick search...
 #### Negated Token
-
 It is possible to negate all tokens using the operator `!`, in regular expression the operator `^` is used for negation.
 ```
 terminal BETWEEN_HASHES:'#' (!'#')* '#';
@@ -124,35 +104,37 @@ A terminal rule can implement other terminal rules.
 terminal DOUBLE returns number: INT '.' INT;
 ```
 Note: it is easy to create conflict between terminal rules by using *terminal rule calls*. See [Data Type Rules](#data-type-rules) for further details.
+
 #### Alternatives
-It is possible to match several valid options. The terminal rule for white space can use alternatives as:
+It is possible to match several valid options. The terminal rule `STRING` can use alternatives to match a sequence of characters between double quotes `""` or single quotes `''`:
 ```
-terminal WS: (' '|'\t'|'\r'|'\n')+;
+terminal STRING: /"[^"]*"|'[^']*'/;
 ```
+
 #### Groups
 Tokens can be put in sequence specifying the order they have to appear
 ```
-terminal FLIGHTNUMBER: ('A'..'Z')('A'..'Z')('0'..'9')('0'..'9')('0'..'9')('0'...'9')?;
+terminal FLIGHT_NUMBER: ('A'..'Z')('A'..'Z')('0'..'9')('0'..'9')('0'..'9')('0'...'9')?;
 ```
-In this example, the token `FLIGHTNUMBER` must start with two capital letters and followed by three of four digits.
+In this example, the token `FLIGHT_NUMBER` **must** start with two capital letters and followed by three of four digits.
 
 ### Terminal Fragments
 Fragments allow for sub-definition of terminal rules to be extracted. They are not consumed by the lexer and have to be consumed by other terminal rules.
-
 ```
 terminal fragment CAPITAL_LETTER: ('A'..'Z');
 terminal fragment SMALL_LETTER: ('a'..'z');
 terminal NAME: CAPITAL_LETTER SMALL_LETTER+;
 ```
+In this example, the lexer will not transform a single capital or small letter into a valid token but will match a sequence of one capital letter followed by one or many small letters.
 
 ### Hidden Terminal Rules
-The parser will try to match every character in the document to a terminal rules. It is therefore necessary to specify which characters or sequence of characters need to be ignored during parsing. Generally, you would want to ignore whitespaces and comments. This is achieved by adding the keyword `hidden` in front of the keyword `terminal`. These *hidden terminal rules* are global and will be valid for all parser rules in the document.
+The parser tries to match every character in the document to a terminal rules. It is therefore necessary to specify which characters or sequence of characters need to be ignored during parsing. Generally, you would want to ignore whitespaces and comments. This is achieved by adding the keyword `hidden` in front of the keyword `terminal` when defining a *terminal rule*. These *hidden terminal rules* are global and will be valid for all parser rules in the document.
 ```
 hidden terminal WS: /\s+/;
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;
 ```
-[QUESTION] The Xtext doc says that hidden terminals can be added to specific parser rules. Is this valid for Langium? I couldn't make it work on my test project.
+
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
 
@@ -164,27 +146,43 @@ Parser rules have access to a more restricted set of EBNF expressions compared t
 - Rule calls
 
 Parser rules also have their own expressions as described below.
+
 #### Declaration
-A parser rule always starts with the name of the rule followed by an optional return type. If no return type is specified, the parser assumes that the object created has the type of the parser rule's name.
+A parser rule always starts with the name of the rule followed by an optional return type. If no return type is specified, the parser assumes that the object to be created has the type of the parser rule's name.
 ```
 Person:
     'person' name=ID;
 ``` 
-In this example, the parser will create an object of type `Person`. This object will have a property `name` which value and type must match the terminal rule `ID` (i.e. the property `name` is of type `string`).
+In this example, the parser will create an object of type `Person`. This object will have a property `name` which value and type must match the terminal rule `ID` (i.e. the property `name` is of type `string` and cannot start with a digit or special character).
 
 #### Keywords
-A parser rule that creates an object starts with a keyword. The keyword must match the regular expression `/\^?[_a-zA-Z][\w_]*/` and appear in the grammar file between single quotes.
+Keywords are meant to guide the parser in defining what type of object needs to be parsed.
+A keyword must match the regular expression `/\^?[_a-zA-Z][\w_]*/` and appear in the grammar file between single quotes `''`.
 
+Consider the following:
+```
+Person:
+    name=ID;
+
+City:
+    name=ID;
+```
+The parser will not be able to differentiate between the parsing of `Person` or `City` if it encounters a token matching the terminal rule `ID`. We can include *keywords* to remove the ambiguity:
 ```
 Person:
     'person' name=ID;
+
+City:
+    'city' name=ID;
 ```
-In this example, the keyword `person` indicates to the parser that an object of type `Person` must be parsed. A parser rule can have many keywords:
+Now the parser is able to differentiate between the two parser rules and will successfully parse objects of type `Person` and `City`.
+
+Parser rules can have many keywords:
 ```
 Person:
     'person' name=ID 'age' age=INT;
 ```
-[QUESTION] Are there keywords that are reserved for the Langium grammar ('grammar', 'terminal', 'fragment' ...)? Or can a rule "override" the use of those keywords?
+
 #### Assignments
 There are three different ways to assign an expression (right side) to a property (left side).
 
@@ -193,7 +191,8 @@ There are three different ways to assign an expression (right side) to a propert
     Person:
         'person' name=ID
     ```
-    Here, the property `name` will only accept one expression matching the terminal rule `ID`.
+    Here, the property `name` will accept only one expression matching the terminal rule `ID`.
+
 2. `+=` is used to assign **multiple expressions** to a list property
     ```
     Paragraph:
@@ -203,15 +202,21 @@ There are three different ways to assign an expression (right side) to a propert
     ```
     paragraph "The expression group " 3 "was interrupted"
     ```
-    will throw an error since the `STRING` expressions are not continuous. It is however possible to interrupt and resume a sequence of expressions by using [hidden terminal symbols](#hidden-terminal-symbols).
-3. `?=` is used to assign a **value to a property of type boolean**. The value of the property of type `boolean` is set to `true` if the right part of the assignment is consumed by the parser
+    will throw an error since the `STRING` expressions are not continuous. It is however possible to interrupt and resume a sequence of expressions by using [hidden terminal symbols](#hidden-terminal-symbols):
+    ```
+    paragraph "expression one" /* comment */ "expression two"
+    ```
+    The above example will be successfully parsed.
+
+3. `?=` is used to assign a **value to a property of type boolean**. The value of the property of type `boolean` is set to `true` if the right part of the assignment is consumed by the parser.
     ```
     Employee:
         'employee' name=ID (remote?='remote')?
     ```
     Here the value of the property `remote` will be set to true if the keyword `remote` appears in the document.
+
 #### Cross-reference
-With Langium, you can declare cross-references directly in the grammar.
+With Langium, you can declare *cross-references* directly in the grammar. 
 ```
 Person:
     'person' name=ID;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -1,7 +1,7 @@
 ---
 title: "The Grammar Language"
 ---
-The grammar language describes the syntax and structure of your language. The [Langium grammar langium](https://github.com/langium/langium/blob/main/packages/langium/src/grammar/langium-grammar.langium) is implemented using Langium itself and therefore follows the same syntactic rules as any language created with Langium.
+The grammar language describes the syntax and structure of your language. The [Langium grammar langium](https://github.com/langium/langium/blob/main/packages/langium/src/grammar/langium-grammar.langium) is implemented using Langium itself and therefore follows the same syntactic rules as any language created with Langium. The grammar language will define the structure of the *abstract syntax tree* (AST) which in Langium is a collection of Javascript objects describing their properties and how they are linked to each other.
 
 In the following, we describe the Langium syntax and document structure.
 ## Language Declaration

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -1,8 +1,9 @@
 ---
 title: "The Grammar Language"
 ---
-[TODO] INTRODUCTION TEXT ABOUT THE GRAMMAR LANGUAGE
+The grammar language describes the syntax and structure of your language. The [Langium grammar langium](https://github.com/langium/langium/blob/main/packages/langium/src/grammar/langium-grammar.langium) is implemented using Langium itself and therefore follows the same syntactic rules as any language created with Langium.
 
+In the following, we describe the Langium syntax and document structure.
 ## Language Declaration
 
 A Langium grammar file starts with a header which declares the name of the language
@@ -229,6 +230,7 @@ AbstractDefinition:
 ```
 The parser rule `AbstractDefinition` will not create an object of type AbstractDefinition. Instead, it calls either the `Definition` or `DeclaredParameter` parser rule which will create an object of type Definition or DeclaredParameter respectively. 
 #### Assigned Actions
+
 ### Syntactic Predicates
 ## Hidden Terminal Symbols
 [QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -6,7 +6,7 @@ The grammar language describes the syntax and structure of your language. The [L
 In the following, we describe the Langium syntax and document structure.
 ## Language Declaration
 
-A Langium grammar file always starts with a header which declares the name of the language
+A Langium grammar file always starts with a header which declares the name of the language. For example, a language named `LanguageName` would be declared with:
 
 ```
 grammar LanguageName
@@ -14,11 +14,17 @@ grammar LanguageName
 
 Every grammar file has a `.langium` extension and needs to be referenced in `langium-config.json`. If you used the `langium-generator` to start your project then your language was automatically referenced in `langium-config.json`.
 
-[TODO] ADD IMPORT OF OTHER GRAMMAR FILES
+### Import other grammar languages
+It is possible to reuse grammar rules from other `.langium` files by importing them into your grammar file.
 
+```
+import 'path/to/an/other/langium/grammar';
+```
+This will import **all grammar rules** from the imported grammar file. It is therefore crucial to ensure that there are no duplicate rules between the different grammar files.
+
+[QUESTION] Is the above sentence true? Or is there a way to import only part of a grammar?
 ## Terminal Rules
-
-Lexing transforms a stream of character into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a specific *terminal rule*. The names of terminal rules are conventionally written in upper case. The matching of terminal rules follows *regular expressions*.
+Lexing transforms a stream of characters into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a specific *terminal rule*. The names of terminal rules are conventionally written in upper case. The matching of terminal rules follows *regular expressions*.
 
 ```
 terminal STRING: /"[^"]*"|'[^']*'/;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -144,6 +144,15 @@ terminal fragment CAPITAL_LETTER: ('A'..'Z');
 terminal fragment SMALL_LETTER: ('a'..'z');
 terminal NAME: CAPITAL_LETTER SMALL_LETTER+;
 ```
+
+### Hidden Terminal Rules
+The parser will try to match every character in the document to a terminal rules. It is therefore necessary to specify which characters or sequence of characters need to be ignored during parsing. Generally, you would want to ignore whitespaces and comments. This is achieved by adding the keyword `hidden` in front of the keyword `terminal`. These *hidden terminal rules* are global and will be valid for all parser rules in the document.
+```
+hidden terminal WS: /\s+/;
+hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
+hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;
+```
+[QUESTION] The Xtext doc says that hidden terminals can be added to specific parser rules. Is this valid for Langium? I couldn't make it work on my test project.
 ## Parser Rules
 [TODO] INTRODUCTION ABOUT PARSER RULES
 
@@ -295,8 +304,7 @@ Addition:
 
 [TODO] Add part about syntax leading to unwanted elements in the tree.
 ### Syntactic Predicates
-## Hidden Terminal Symbols
-[QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. it doesn't work so needs to be declared as a 'global' token
+
 ## Data Type Rules
 ## Enum Rules
 [QUESTION] DOES LANGIUM SUPPORTS ENUM? PR#84 removed enum and added primitive instead

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -219,7 +219,7 @@ There are three different ways to assign an expression (right side) to a propert
     Here the value of the property `remote` will be set to `true` if the keyword `remote` was successfully parsed as a part of the rule call.
 
 #### Cross-reference
-With Langium, you can declare *cross-references* directly in the grammar. *Cross-reference* allows to reference an object of a given type. The syntax is:
+With Langium, you can declare *cross-references* directly in the grammar. A *cross-reference* allows to reference an object of a given type. The syntax is:
 ```
 property=[Type:TOKEN]
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -202,7 +202,26 @@ There are three different ways to assign an expression (right side) to a propert
     ```
     Here the value of the property `remote` will be set to true if the keyword `remote` appears in the document.
 #### Cross-reference
-[TODO] CHECK IN MORE DETAILS, I DON'T UNDERSTAND THE SYNTAX AND HOW IT'S IMPLEMENTED
+With Langium, you can declare cross-references directly in the grammar.
+```
+Person:
+    'person' name=ID;
+Greeting:
+    'Hello' person=[Person:ID] '!';
+```
+The `Person` in square brackets does not refer to a parser rule `Person` but instead refers to an object of type `Person`. It will successfully parse a document like:
+```
+person Bob
+Hello Bob !
+```
+but will fail to parse:
+```
+person Bob
+Hello Sara !
+```
+because a `Person` object with the ID of 'Sara' has not been instantiated.
+
+[QUESTION] I failed to reference an instance with using something else than ID. Reading teh Xtext doc and the langium-grammar it seems like it is possible but I couldn't figure out how...
 #### Unordered Groups
 By default, a parser rule has to be implemented in the exact order it is declared.
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -235,12 +235,12 @@ The `Person` in square brackets does not refer to the parser rule `Person` but i
 person Bob
 Hello Bob !
 ```
-but will fail to parse:
+but the following:
 ```
 person Bob
 Hello Sara !
 ```
-because a `Person` object with the ID of 'Sara' has not been instantiated even though 'Sara' is a valid `ID`.
+will result in an error message since the cross reference resolution will fail because a `Person` object with the ID of 'Sara' has not been instantiated even though 'Sara' is a valid `ID`.
 
 #### Unordered Groups
 [NOTE] Unordered group are currently not supported but seems like it's being worked on. I think this is still valuable info that could be added to the documentation at a later stage if needed.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -2,20 +2,120 @@
 title: "The Grammar Language"
 ---
 
+
 ## Language Declaration
 
-## Terminal Rules
-### Return Types
-### Extended Backus-Naur Form Expressions
-#### Keywords
-#### Character Range
-#### Wildcard
-#### Until Token
-#### Negated Token
-#### Rule Calls
-#### Alternatives
-#### Groups
+A Langium grammar file starts with a header which declares the name of the language
 
+```
+grammar LanguageName
+```
+
+Every grammar file have the file extension `.langium` and needs to be referenced in `langium-config.json`
+
+[TODO] ADD IMPORT OF OTHER GRAMMAR FILES
+
+## Terminal Rules
+
+Lexing transforms a stream of character into a stream of tokens. Tokens are a sequence of one or many characters which is matched by a specific *terminal rule*. The names of terminal rules are conventionally written in upper case. The matching of terminal rules follows *regular expressions*.
+
+```
+terminal STRING: /"[^"]*"|'[^']*'/;
+```
+
+Here, the token `STRING` will match a stream of character surrounded by double quotes `""` or single quotes `''`.
+
+**The order in which terminal rules are defined is critical** as the lexer will always return the first match.
+
+### Return Types
+
+A terminal rule returns a Typescript type. If no return type is specified then the terminal rule will return a `string` by default. 
+
+```
+terminal INT returns number: /[0-9]+/;
+```
+
+Here, the terminal rule `INT` will return an instance of `number`.
+The available return types in Langium are: 
+- `string`
+- `number`
+- `boolean`
+- ...
+
+[QUESTION] WHAT ARE ALL THE AVAILABLE RETURN TYPES?
+
+### Extended Backus-Naur Form Expressions
+Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions.
+#### Cardinalities
+Four different cardinalities can be defined for any expression:
+1. exactly one (no operator)
+2. zero or one (operator ?)
+3. zero or many (operator *)
+4. one or many (operator +)
+#### Keywords
+[QUESTION] SHOULD THIS PART BE ONLY ABOUT THE RESERVED KEYWORDS? KEYWORDS USED FOR TERMINAL RULES ONLY?
+Keywords are terminal rules used by the Langium grammar itself. 
+- `grammar`
+- `import`
+- `entry`
+- `hidden`
+- `fragment`
+
+[QUESTION] WHAT ARE ALL THE KEYWORDS IN THE LANGIUM GRAMMAR AND SHOULD THEY BE EXPLAINED HERE OR IN THEIR RESPECTIVE SECTION?
+
+#### Character Range
+The operator `..` is used to declare a character range. It is equivalent to the operator `-`in regular expression.
+
+```
+terminal INT returns number: ('0'..'9')+;
+```
+
+is equivalent to
+
+```
+terminal INT returns number: /[0-9]+/;
+```
+
+Here, INT is matched to one or more characters (by using the operand `+`) between '0' and '9' (inclusive).
+
+#### Wildcard
+The operator `.` is used to match any character and is similar in regular expression.
+
+[TODO] FIND GOOD EXAMPLE WITH THE WILDCARD USED
+
+#### Until Token
+The operator `->` indicates that all characters should be consumed from one token until a specific token occurs. For example, the terminal rule for multi-line comment can be implemented as:
+
+```
+terminal ML_COMMENT: '/*' -> '*/';
+```
+Regular expression equivalent:
+```
+terminal ML_COMMENT: /\/\*(.*?)\*\//;
+```
+#### Negated Token
+
+It is possible to negate all tokens using the operator `!`
+```
+terminal ML_COMMENT: '/*' (!'*/')* '/*'; 
+```
+
+#### Rule Calls
+A terminal rule can implement other terminal rules. 
+```
+terminal DOUBLE: INT '.' INT;
+```
+#### Alternatives
+It is possible to match several valid options. The terminal rule for white space can use alternatives as:
+```
+terminal WS: (' '|'\t'|'\r'|'\n')+;
+```
+#### Groups
+Tokens can be put in sequence specifying the order they have to appear
+```
+terminal FLIGHTNUMBER: ('A'..'Z')('A'..'Z')('0'..'9')('0'..'9')('0'..'9')('0'...'9')?;
+```
+In this example, the token `FLIGHTNUMBER` must start with two capital letters and followed by three of four digits.
 ## Parser Rules
 ### Extended Backus-Naur Form Expressions
 #### Assignements

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -103,7 +103,7 @@ A terminal rule can implement other terminal rules.
 ```
 terminal DOUBLE returns number: INT '.' INT;
 ```
-Note: it is easy to create conflict between terminal rules by using *terminal rule calls*. See [Data Type Rules](#data-type-rules) for further details.
+Note that it is easy to create conflict between terminal rules by using *terminal rule calls*. See [Data Type Rules](#data-type-rules) for further details.
 
 #### Alternatives
 It is possible to match several valid options. The terminal rule `STRING` can use alternatives to match a sequence of characters between double quotes `""` or single quotes `''`:

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -297,7 +297,7 @@ AbstractDefinition:
 ```
 The parser rule `AbstractDefinition` will not create an object of type AbstractDefinition. Instead, it calls either the `Definition` or `DeclaredParameter` parser rule which will be responsible for creating an object of a given type (or call other parser rules if they are unassigned rule calls themselves). 
 
-#### Assigned Actions
+#### Tree-Rewriting Actions
 The parser is built using [Chevrotain](https://github.com/chevrotain/chevrotain) which implements a LL(k) parsing algorithm (left-to-right). By definition, a LL(k) grammar cannot have rules containing left recursion.
 
 Consider the following: 

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -37,20 +37,23 @@ Here, the token `ID` will match a stream of character starting with the characte
 
 ### Return Types
 
-A terminal rule always returns an instance of a Typescript type. If no return type is specified then the terminal rule will return a `string` by default. 
+A terminal rule always returns an instance of a `Typescript primitive type`. If no return type is specified then the terminal rule will return a `string` by default. 
+
+[QUESTION] Is the return type always a primitive type?
 
 ```
+terminal ID: /[_a-zA-Z][\w_]*/;
 terminal INT returns number: /[0-9]+/;
 ```
 
-Here, the terminal rule `INT` will return an instance of `number`.
+Here, the terminal rule `ID` will return an instance of `string` while the terminal rule `INT` will return an instance of `number`.
+
 The available return types in Langium are: 
 - `string`
 - `number`
 - `boolean`
-- ...
-
-[QUESTION] WHAT ARE ALL THE AVAILABLE RETURN TYPES?
+- `bigint`
+[QUESTION] What are the available return types?
 
 ### Extended Backus-Naur Form Expressions
 Terminal rules can be described using *regular expressions* or *Extended Backus-Naur Form*-like (EBNF) expressions similar to the [Xtext](https://www.eclipse.org/Xtext/) notation.

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -223,7 +223,7 @@ because a `Person` object with the ID of 'Sara' has not been instantiated even t
 
 [QUESTION] I failed to reference an instance with using something else than ID. Reading the Xtext doc and the langium-grammar it seems like it is possible but I couldn't figure out how...
 #### Unordered Groups
-[NOTE] Unordered group are currently unsupported but seems like it's being worked on. Let's consider the following as something that could be added when the feature is available.
+[NOTE] Unordered group are currently not supported but seems like it's being worked on. I think this is still valuable info that could be added to the documentation at a later stage if needed.
 
 By default, a parser rule has to be implemented in the exact order it is declared.
 ```
@@ -276,7 +276,24 @@ AbstractDefinition:
 ```
 The parser rule `AbstractDefinition` will not create an object of type AbstractDefinition. Instead, it calls either the `Definition` or `DeclaredParameter` parser rule which will create an object of type Definition or DeclaredParameter respectively. 
 #### Assigned Actions
+The parser is built using Chevrotain which implements a LL(k) parsing algorithm (left-to-right). By definition, a LL(k) grammar cannot have rules containing left recursion.
 
+Consider the following: 
+```
+Addition:
+    Addition '+' Addition | '(' Addition ')' | value=INT;
+```
+The parser rule `Addition` is left-recursive and will not be parsable. We can go around this issue by *left-factoring* the rule, *i.e.* by factoring out the common left-factor. We introduce a new rule `Expression`:
+```
+Expression:
+    '(' Addition ')' | value=INT;
+
+Addition:
+    Expression ('+' Expression)*;
+```
+[NOTE] Contrary to the Xtext doc, I had to had `value=` for the code to compile, otherwise is throws a `RangeError: Maximum call stack size exceeded`. Any idea why?
+
+[TODO] Add part about syntax leading to unwanted elements in the tree.
 ### Syntactic Predicates
 ## Hidden Terminal Symbols
 [QUESTION] THE XTEXT DOC SAYS THAT HIDDEN TERMINALS CAN BE ADDED TO SPECIFIC PARSER RULES. IS THIS VALID FOR LANGIUM? I COULDN'T MAKE IT WORK ON MY SETUP. it doesn't work so needs to be declared as a 'global' token

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -1,7 +1,7 @@
 ---
 title: "The Grammar Language"
 ---
-The grammar language describes the syntax and structure of your language. The [Langium grammar langium](https://github.com/langium/langium/blob/main/packages/langium/src/grammar/langium-grammar.langium) is implemented using Langium itself and therefore follows the same syntactic rules as any language created with Langium. The grammar language will define the structure of the *abstract syntax tree* (AST) which in Langium is a collection of Javascript objects describing their properties and how they are linked to each other.
+The grammar language describes the syntax and structure of your language. The [Langium grammar language](https://github.com/langium/langium/blob/main/packages/langium/src/grammar/langium-grammar.langium) is implemented using Langium itself and therefore follows the same syntactic rules as any language created with Langium. The grammar language will define the structure of the *abstract syntax tree* (AST) which in Langium is a collection of Javascript objects describing their properties and how they are linked to each other.
 
 In the following, we describe the Langium syntax and document structure.
 ## Language Declaration

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -298,7 +298,7 @@ AbstractDefinition:
 The parser rule `AbstractDefinition` will not create an object of type AbstractDefinition. Instead, it calls either the `Definition` or `DeclaredParameter` parser rule which will be responsible for creating an object of a given type (or call other parser rules if they are unassigned rule calls themselves). 
 
 #### Tree-Rewriting Actions
-The parser is built using [Chevrotain](https://github.com/chevrotain/chevrotain) which implements a LL(k) parsing algorithm (left-to-right). By definition, a LL(k) grammar cannot have rules containing left recursion.
+The parser is built using [Chevrotain](https://github.com/chevrotain/chevrotain) which implements a LL(k) parsing algorithm (left-to-right). Conceptually, a LL(k) grammar cannot have rules containing left recursion.
 
 Consider the following: 
 ```

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -282,7 +282,7 @@ RuleOne returns TypeOne:
 RuleTwo returns TypeTwo:
     'keywordTwo' name=ID;
 ```
-In the above example, we rely on a *rule call* to specify the return type. With more complex rules, the readability will be highly impacted. *Actions* allow to improve the readability of the grammar by explicitly defining the return type. *Actions* are declared inside of curly brackets `{}`:
+In the above example, we rely on a *rule call* to specify the return type. With more complex rules, the readability will be highly impacted. *Actions* allow to improve the readability of the grammar by explicitly defining the return type. *Actions* are declared inside of curly braces `{}`:
 ```
 RuleName returns TypeOne:
     'keywordOne' name=ID | 'keywordTwo' {TypeTwo} name=ID;

--- a/content/docs/grammar-language.md
+++ b/content/docs/grammar-language.md
@@ -311,7 +311,8 @@ Addition:
     Expression ('+' Expression)*;
 ```
 
-[TODO] Add part about syntax leading to unwanted elements in the tree.
+[NOTE] I left out the part regarding `tree rewrite actions` as I think it could be part of a more advanced documentation part on the AST/CST. I can add it if we think it belongs here.
+
 ### Syntactic Predicates
 Sometimes it is difficult to describe a problem without an ambiguous grammar. We can guide the parser through the grammar language by introducing *syntactic predicates*.
 In parser generator, a classical example of such ambiguous grammar is the *dangling else problem*. A simple `if-then else` statement is unambiguous:
@@ -345,11 +346,26 @@ QualifiedName returns string:
 ```
 Data type rules need to specify a primitive return type.
 
-## The Model Object
- The parser will create objects for valid *parser rules* which will be stored in a *model object*. The model object contains arrays of the different objects grouped by type. In Langium, you define which parsed objects need to be exported into the *model object* by defining a special parser rule starting with the keyword `entry`.
-
+## The Entry Rule
+The *entry rule* is a parser rule that defines the starting point of the parsing step. The *entry rule* starts with the keyword `entry` and matches other parser rules.
  ```
  entry Model:
     (persons+=Person | greetings+=Greeting)*;
  ```
-The *model object* of type `Model` will have two properties:  an array of objects of type `Person` and a second one of objects of types `Greeting`.
+In this example, the *entry rule* `Model` defines a group of alternatives. The parser will go through the input document and try to parse a `Person` or a `Greeting` object and add it to the array `persons` or `greetings`, respectively. Thanks to the grouping and the cardinality of zero or many (`*`), the parser will go through the document until all inputs have been consumed.
+
+Not all parser rules need to be registered in the parser rule.
+```
+entry Model:
+    (persons+=Person | greetings+=Greeting)*;
+
+Person:
+    'person' name=ID address=Address;
+
+Greeting:
+    'Hello' person=[Person] '!';
+
+Address:
+    street=STRING city=ID postcode=INT;
+```
+We expended the `Person` parser rule to include a property `address` which matches the parser rule `Address`. We decided that an `Address` will never be present in the input document on its own and will always be parsed in relation to a `Person`. It is therefore not necessary to include an array of `Address` inside of the entry rule.


### PR DESCRIPTION
Here is a first draft to the grammar language section of the Langium documentation.

Open for any suggestion about the content, structure, etc.

Most likely some parts need to be reworked to be in line with v0.3