### PR TITLE
Changed margins on headings

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -142,10 +142,13 @@
     margin-bottom: 0.5em;
   }
 
-  .gdoc-markdown h2, h3, h4 {
+  .gdoc-markdown h3, h4 {
     margin-top: 1.5em;
   }
 
+  .gdoc-markdown h2 {
+    margin-top: 2.0em;
+  }
   .gdoc-markdown p {
     margin-block-start: 0px;
   }

--- a/static/custom.css
+++ b/static/custom.css
@@ -136,3 +136,28 @@
       --footer-link-color-visited: rgb(213, 104, 231);
     }
   }
+
+
+  .gdoc-markdown h1,h2,h3,h4,h5,h6{
+    margin-bottom: 0.5em;
+  }
+
+  .gdoc-markdown h2, h3, h4 {
+    margin-top: 1.5em;
+  }
+
+  .gdoc-markdown p {
+    margin-block-start: 0px;
+  }
+
+  .gdoc-markdown h2 {
+    font-size: 1.5rem;
+  }
+
+  .gdoc-markdown h3 {
+    font-size: 1.25rem;
+  }
+
+  .gdoc-markdown h4 {
+    font-size: 1.125rem;
+  }


### PR DESCRIPTION
Resolves #24

Changed the margins on headings and paragraphs to look less monotonous.

It works by overriding CSS rules from the hugo theme via `static/custom.css`. The modified classes are at the bottom of `static/custom.css`.