### PR TITLE
Fix Footer Issues & Missing Font for Showcase

### DIFF
--- a/hugo/layouts/partials/langium-footer.html
+++ b/hugo/layouts/partials/langium-footer.html
@@ -1,16 +1,18 @@
 <!-- Footer Menu -->
-<footer class="flex dark:text-gray-100 justify-center items-center mt-12 mb-6">
-    <div class="border-r-2 dark:border-gray-100 px-5">
+<footer class="font-mono block md:flex dark:text-gray-100 justify-center items-center mt-12 mb-6">
+    <div class="hover:underline px-4 block text-left md:text-center m-4" style="width:180px">
         <a href="https://www.typefox.io/imprint-privacy/#privacy">
             Privacy Policy
         </a>
     </div>
-    <div class="border-r-2 dark:border-gray-100 px-5">
+    <span class="text-lg hidden md:inline">|</span>
+    <div class="hover:underline px-4 block text-left md:text-center m-4" style="width:180px">
         <a href="https://www.typefox.io/imprint-privacy/#copyright">
             Copyright
         </a>
     </div>
-    <div class="px-5">
+    <span class="text-lg hidden md:inline">|</span>
+    <div class="hover:underline px-4 block text-left md:text-center m-4" style="width:180px">
         <a href="/imprint">
             Imprint
         </a>

--- a/hugo/layouts/partials/langium-header.html
+++ b/hugo/layouts/partials/langium-header.html
@@ -1,4 +1,4 @@
-<header>
+<header class="font-mono">
     <div class="flex justify-between items-center px-4 py-6 sm:px-6 md:space-x-10">
         <div class="flex justify-start lg:w-0 lg:flex-1">
             <a href="/#">


### PR DESCRIPTION
This addresses some issues that are visible on the current site regarding the footer and showcase page, these are:
- footer elements are not centered
- footer does not compress well for mobile view
- header & footer font is overriden by monaco for the showcase page
The following gif shows these issues:
![a2](https://user-images.githubusercontent.com/5070304/190649572-ffcdef68-d4d6-4ac9-bd04-7b88bc54bcf0.gif)

And this one demonstrates these issues fixed in this PR.
![langiumwebsite](https://user-images.githubusercontent.com/5070304/190649182-cf250d5c-58af-4dcd-9a87-0bbcabeabf59.gif)
