### PR TITLE
Fix comment order

### DIFF
--- a/hugo/content/docs/ast-types.md
+++ b/hugo/content/docs/ast-types.md
@@ -232,12 +232,13 @@ Let's look at the example from the previous section:
 X infers MyType: name=ID;
 Y infers MyType: name=ID count=INT;
 
-// should be replaced by:
+// generates:
 interface MyType {
     name: string
     count?: number
 }
 
+// should be replaced by:
 X returns MyType: name=ID;
 Y returns MyType: name=ID count=INT;
 ```


### PR DESCRIPTION
The comment "// should be replaced by:" was pointing to the generated JS code instead of the refactored code. I just added the right comment for the generated JS code, and I moved the original comment to the right position