### PR TITLE
Improve dummy rule documentation

### DIFF
--- a/hugo/content/docs/grammar-language.md
+++ b/hugo/content/docs/grammar-language.md
@@ -74,7 +74,7 @@ Person:
 ```
 In this example, the parser will create an object of type `Person`. This object will have a property `name` which value and type must match the terminal rule `ID` (i.e. the property `name` is of type `string` and cannot start with a digit or special character).
 
-By default, the parser will create an object with an inferred type corresponding to the parser rule name. It is possible to override this behavior by explicitly defining the type of the object to be created. This is done by adding the keyword `returns` followed by a separately declared type, or the keyword `infers` followed by the name of the type to be inferred for this rule (more about this [in the next chapter](../ast-types)):
+By default, the parser will create an object with an inferred type corresponding to the parser rule name. It is possible to override this behavior by explicitly defining the type of the object to be created. This is done by adding the keyword `returns` followed by a separately declared type, or the keyword `infers` followed by the name of the type to be inferred for this rule (more about this [in the next chapter](../sematic-model)):
 ```
 Person infers OtherType:
     'person' name=ID;
@@ -226,7 +226,7 @@ RuleOne returns TypeOne:
     'keywordOne' name=ID | {TypeTwo} 'keywordTwo' name=ID;
 ```
 
-The example above requires that the return types `TypeOne` and `TypeTwo` are declared separately (see [the next chapter](../ast-types)). If the type returned by the action is created on-the-fly, the keyword `infer` needs to be added:
+The example above requires that the return types `TypeOne` and `TypeTwo` are declared separately (see [the next chapter](../semantic-model)). If the type returned by the action is created on-the-fly, the keyword `infer` needs to be added:
 ```
 RuleOne infers TypeOne:
     'keywordOne' name=ID | {infer TypeTwo} 'keywordTwo' name=ID;


### PR DESCRIPTION
The current documentation explains fairly well how to refactor dummy rules, but doesn't really explain why they are sometimes needed in the first place.

This change addresses this, as it proposes a use case, where we first introduce a problem, which can be solved by using a dummy rule. Afterwards, we refactor our solution using declared types to remove the dummy rule again.