### PR TITLE
Add share feature to playground

### DIFF
--- a/hugo/content/playground/_index.html
+++ b/hugo/content/playground/_index.html
@@ -8,6 +8,7 @@ description: Write your own language on the left and try out your own language e
 geekdochidden: false
 draft: false
 noMain: true
+playground: true
 ---
 <link rel="preload" as="script" href="./libs/worker/common.js"/>
 <link rel="preload" as="script" href="./libs/worker/langiumServerWorker.js"/>
@@ -36,10 +37,16 @@ noMain: true
     divRoot.appendChild(leftEditor);
     divRoot.appendChild(rightEditor);
 
+    const url = new URL(window.location.toString());
+    const grammar = url.searchParams.get('grammar');
+    const content = url.searchParams.get('content');
+
     setupPlayground(
       (name) => new MonacoEditorLanguageClientWrapper(name),
       leftEditor,
-      rightEditor
+      rightEditor,
+      grammar,
+      content
     );
   });
 </script>

--- a/hugo/content/playground/common.ts
+++ b/hugo/content/playground/common.ts
@@ -1,3 +1,9 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
 import {
   AbstractMessageReader,
   DataCallback,

--- a/hugo/content/playground/data.ts
+++ b/hugo/content/playground/data.ts
@@ -1,3 +1,9 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
 export const LangiumMonarchContent = {
   keywords: [
     "bigint",

--- a/hugo/content/playground/langium-worker.ts
+++ b/hugo/content/playground/langium-worker.ts
@@ -1,3 +1,9 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
 import { DocumentState, startLanguageServer, EmptyFileSystem, createLangiumGrammarServices } from 'langium';
 import { createConnection, DiagnosticSeverity } from 'vscode-languageserver/browser';
 import { ByPassingMessageReader, ByPassingMessageWriter, PlaygroundWrapper } from './common';

--- a/hugo/content/playground/monarch-generator.ts
+++ b/hugo/content/playground/monarch-generator.ts
@@ -1,3 +1,9 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
 import * as langium from "langium";
 import {
   getTerminalParts,

--- a/hugo/content/playground/share-link.ts
+++ b/hugo/content/playground/share-link.ts
@@ -4,13 +4,15 @@ export function registerShareLink(callback: () => {
     grammar: string,
     content: string
 }): void {
+    const copyText = "Copy URL to clipboard";
+    getTooltip().textContent = copyText;
     const shareLink = document.getElementById("share-link");
     shareLink?.addEventListener('click', () => {
         const { grammar, content } = callback();
         copyToClipboard(grammar, content);
     });
     shareLink?.addEventListener('mouseleave', () => {
-        getTooltip().textContent = "Copy to clipboard";
+        getTooltip().textContent = copyText;
     });
 }
 
@@ -21,7 +23,7 @@ async function copyToClipboard(grammar: string, content: string): Promise<void> 
     url.searchParams.append('grammar', compressedGrammar);
     url.searchParams.append('content', compressedContent);
     await navigator.clipboard.writeText(url.toString());
-    getTooltip().textContent = "Copied to clipboard!";
+    getTooltip().textContent = "Copied URL to clipboard!";
   }
   
 function getTooltip(): HTMLElement {

--- a/hugo/content/playground/share-link.ts
+++ b/hugo/content/playground/share-link.ts
@@ -1,3 +1,9 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
 import { compressToEncodedURIComponent } from "lz-string";
 
 export function registerShareLink(callback: () => {

--- a/hugo/content/playground/share-link.ts
+++ b/hugo/content/playground/share-link.ts
@@ -1,0 +1,29 @@
+import { compressToEncodedURIComponent } from "lz-string";
+
+export function registerShareLink(callback: () => {
+    grammar: string,
+    content: string
+}): void {
+    const shareLink = document.getElementById("share-link");
+    shareLink?.addEventListener('click', () => {
+        const { grammar, content } = callback();
+        copyToClipboard(grammar, content);
+    });
+    shareLink?.addEventListener('mouseleave', () => {
+        getTooltip().textContent = "Copy to clipboard";
+    });
+}
+
+async function copyToClipboard(grammar: string, content: string): Promise<void> {
+    const compressedGrammar = compressToEncodedURIComponent(grammar);
+    const compressedContent = compressToEncodedURIComponent(content);
+    const url = new URL('/playground', window.origin);
+    url.searchParams.append('grammar', compressedGrammar);
+    url.searchParams.append('content', compressedContent);
+    await navigator.clipboard.writeText(url.toString());
+    getTooltip().textContent = "Copied to clipboard!";
+  }
+  
+function getTooltip(): HTMLElement {
+    return document.getElementById('share-tooltip')!;
+}

--- a/hugo/content/playground/user-worker.ts
+++ b/hugo/content/playground/user-worker.ts
@@ -1,3 +1,9 @@
+/******************************************************************************
+ * Copyright 2022 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
 import { startLanguageServer } from 'langium';
 import { createServicesForGrammar } from 'langium/lib/grammar/grammar-util';
 import { createConnection } from 'vscode-languageserver/browser';

--- a/hugo/layouts/langium/baseof.html
+++ b/hugo/layouts/langium/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="dark">
 <head>
-    {{ partial "langium-head" }}
+    {{ partial "langium-head" . }}
 </head>
 {{/* Default is mono font, but use the regular font in special cases, like for the imprint page */}}
 {{ $extraBodyClass := `font-mono` }}
@@ -11,7 +11,7 @@
 <body class='bg-white dark:bg-gray-900 {{ $extraBodyClass }}'>
     <div x-data="{ isOpen: false }" class="wrapper relative bg-white dark:bg-gray-900">
 
-        {{ partial "langium-header" }}
+        {{ partial "langium-header" . }}
 
         {{/* Drop main block for showcase pages */}}
         {{ if .Params.noMain }}

--- a/hugo/layouts/langium/baseof.html
+++ b/hugo/layouts/langium/baseof.html
@@ -25,9 +25,9 @@
         {{ else }}
         </main>
         {{ end }}
-        {{ partial "langium-footer" }}
-        {{ partial "langium-mobile-menu" }}
+        {{ partial "langium-footer" . }}
+        {{ partial "langium-mobile-menu" . }}
     </div>
-    {{ partial "langium-scripts" }}
+    {{ partial "langium-scripts" . }}
 </body>
 </html>

--- a/hugo/layouts/partials/langium-footer.html
+++ b/hugo/layouts/partials/langium-footer.html
@@ -1,5 +1,14 @@
 <!-- Footer Menu -->
 <footer class="font-mono block md:flex dark:text-gray-100 justify-center items-center mt-12 mb-6">
+    {{ if .Params.playground }}
+    <div class="px-4 block text-left md:text-center m-4" style="width:180px">
+        <a id="share-link" class="tooltip active:text-emeraldLangium" href="#">
+            <span class="tooltiptext" id="share-tooltip"></span>
+            Share
+        </a>
+    </div>
+    <span class="text-lg hidden md:inline">|</span>
+    {{ end }}
     <div class="hover:underline px-4 block text-left md:text-center m-4" style="width:180px">
         <a href="https://www.typefox.io/imprint-privacy/#privacy">
             Privacy Policy

--- a/hugo/layouts/partials/langium-head.html
+++ b/hugo/layouts/partials/langium-head.html
@@ -24,3 +24,5 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300&display=swap" rel="stylesheet">
+<link rel="preload" href="{{ index .Site.Data.assets "custom.css" | relURL }}" as="style">
+<link rel="stylesheet" href="{{ index .Site.Data.assets "custom.css" | relURL }}" media="all">

--- a/hugo/layouts/partials/langium-header.html
+++ b/hugo/layouts/partials/langium-header.html
@@ -19,6 +19,6 @@
                 </svg>
             </button>
         </div>
-        {{ partial "langium-nav" }}
+        {{ partial "langium-nav" . }}
     </div>
 </header>

--- a/hugo/layouts/partials/langium-nav.html
+++ b/hugo/layouts/partials/langium-nav.html
@@ -1,12 +1,4 @@
-<nav class="md:flex items-center space-x-10 text-gray-1000 dark:text-gray-100 lg:px-12">
-    {{ if .Params.playground }}
-    <div class="tooltip">
-        <button id="share-link" class="nav-link-desktop">
-            <span class="tooltiptext" id="share-tooltip">Copy to clipboard</span>
-            Share
-        </button>
-    </div>
-    {{ end }}
+<nav class="items-center hidden space-x-10 md:flex text-gray-1000 dark:text-gray-100 lg:px-12">
     <a href="/docs/" class="nav-link-desktop">
         Documentation
     </a>

--- a/hugo/layouts/partials/langium-nav.html
+++ b/hugo/layouts/partials/langium-nav.html
@@ -1,4 +1,12 @@
-<nav class="items-center hidden space-x-10 md:flex text-gray-1000 dark:text-gray-100 lg:px-12">
+<nav class="md:flex items-center space-x-10 text-gray-1000 dark:text-gray-100 lg:px-12">
+    {{ if .Params.playground }}
+    <div class="tooltip">
+        <button id="share-link" class="nav-link-desktop">
+            <span class="tooltiptext" id="share-tooltip">Copy to clipboard</span>
+            Share
+        </button>
+    </div>
+    {{ end }}
     <a href="/docs/" class="nav-link-desktop">
         Documentation
     </a>
@@ -8,9 +16,6 @@
     <a href="/playground/" class="nav-link-desktop">
         Playground
     </a>
-    <!-- <a href="#" class="nav-link-desktop">
-        Playground
-    </a> -->
     <a href="https://www.typefox.io/language-engineering/"
         class="nav-link-desktop text-emeraldLangium dark:text-emeraldLangium">
         Support

--- a/hugo/layouts/playground/baseof.html
+++ b/hugo/layouts/playground/baseof.html
@@ -48,9 +48,9 @@
         </div>
         {{ block "main" . }}
         {{ end }}
-        {{ partial "langium-footer" }}
-        {{ partial "langium-mobile-menu" }}
+        {{ partial "langium-footer" . }}
+        {{ partial "langium-mobile-menu" . }}
     </div>
-    {{ partial "langium-scripts" }}
+    {{ partial "langium-scripts" . }}
 </body>
 </html>

--- a/hugo/layouts/playground/baseof.html
+++ b/hugo/layouts/playground/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="dark">
 <head>
-    {{ partial "langium-head" }}
+    {{ partial "langium-head" . }}
     <style>
         html, body, .overlay, .editing-area {
             margin: 0;
@@ -19,10 +19,6 @@
             position: absolute;
             width: 50%;
             top: 0;
-        }
-
-        .hidden {
-            display: none;
         }
 
         .overlay {
@@ -46,7 +42,7 @@
 {{ end }}
 <body class='bg-white dark:bg-gray-900 {{ $extraBodyClass }}'>
     <div x-data="{ isOpen: false }" class="relative bg-white wrapper dark:bg-gray-900">
-        {{ partial "langium-header" }}
+        {{ partial "langium-header" . }}
         <div class="relative bg-white wrapper dark:bg-gray-900">
             <div class="dark:bg-gray-900" id="monaco-editor-root"></div>
         </div>

--- a/hugo/package.json
+++ b/hugo/package.json
@@ -20,9 +20,11 @@
     "watch:gitpod": "npm run build:static && cross-env NODE_ENV=development hugo server --config ./config.toml -D -b `gp url 1313` -d ../public --appendPort=false"
   },
   "devDependencies": {
+    "@types/lz-string": "^1.3.34",
     "esbuild": "^0.15.7",
     "langium": "0.5.0-next.52ab085",
     "langium-statemachine-dsl": "0.5.0-next.f2b3802",
+    "lz-string": "^1.4.4",
     "monaco-editor-workers": "0.34.2",
     "monaco-editor-wrapper": "1.1.0",
     "vscode-languageserver": "8.0.2"

--- a/hugo/static/custom.css
+++ b/hugo/static/custom.css
@@ -201,3 +201,51 @@ h4 {
 .gdoc-post__codecontainer {
     margin-bottom: 8px;
 }
+
+button.nav-link-desktop {
+    border: 2px solid var(--header-font-color);
+    border-radius: 4px;
+    padding: 4px 8px;
+}
+
+button.nav-link-desktop:active {
+    background-color: var(--header-font-color);
+}
+
+.tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+.tooltip .tooltiptext {
+    visibility: hidden;
+    width: 140px;
+    background-color: var(--footer-background);
+    color: var(--body-font-color);
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px;
+    position: absolute;
+    z-index: 1;
+    top: 130%;
+    left: 50%;
+    margin-left: -75px;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent var(--footer-background) transparent;
+}
+
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}

--- a/hugo/static/custom.css
+++ b/hugo/static/custom.css
@@ -202,16 +202,6 @@ h4 {
     margin-bottom: 8px;
 }
 
-button.nav-link-desktop {
-    border: 2px solid var(--header-font-color);
-    border-radius: 4px;
-    padding: 4px 8px;
-}
-
-button.nav-link-desktop:active {
-    background-color: var(--header-font-color);
-}
-
 .tooltip {
     position: relative;
     display: inline-block;
@@ -227,9 +217,9 @@ button.nav-link-desktop:active {
     padding: 5px;
     position: absolute;
     z-index: 1;
-    top: 130%;
+    bottom: 130%;
     left: 50%;
-    margin-left: -75px;
+    margin-left: -70px;
     opacity: 0;
     transition: opacity 0.3s;
 }
@@ -237,12 +227,12 @@ button.nav-link-desktop:active {
 .tooltip .tooltiptext::after {
     content: "";
     position: absolute;
-    bottom: 100%;
+    top: 100%;
     left: 50%;
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: transparent transparent var(--footer-background) transparent;
+    border-color: var(--footer-background) transparent transparent transparent;
 }
 
 .tooltip:hover .tooltiptext {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/lz-string": "^1.3.34",
         "esbuild": "^0.15.7",
         "langium": "0.5.0-next.52ab085",
         "langium-statemachine-dsl": "0.5.0-next.f2b3802",
+        "lz-string": "^1.4.4",
         "monaco-editor-workers": "0.34.2",
         "monaco-editor-wrapper": "1.1.0",
         "vscode-languageserver": "8.0.2"
@@ -235,6 +237,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.11.10",
@@ -1389,9 +1397,10 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.3",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -1889,6 +1898,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "1.3.0",
       "dev": true,
@@ -1937,9 +1955,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3409,6 +3428,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.10",
       "dev": true
@@ -4151,7 +4176,9 @@
       }
     },
     "got": {
-      "version": "11.8.3",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
@@ -4417,9 +4444,11 @@
     "langium-website-hugo": {
       "version": "file:hugo",
       "requires": {
+        "@types/lz-string": "^1.3.34",
         "esbuild": "^0.15.7",
         "langium": "0.5.0-next.52ab085",
         "langium-statemachine-dsl": "0.5.0-next.f2b3802",
+        "lz-string": "^1.4.4",
         "monaco-editor-workers": "0.34.2",
         "monaco-editor-wrapper": "1.1.0",
         "vscode-languageserver": "8.0.2"
@@ -4484,6 +4513,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "dev": true
+    },
     "make-dir": {
       "version": "1.3.0",
       "dev": true,
@@ -4514,7 +4549,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"


### PR DESCRIPTION
Closes https://github.com/langium/langium-website/issues/89

Adds a button to the playground that puts a playground URL with compressed grammar and content into the clipboard. Any user who opens that URL will be presented with the original grammar and content.