### PR TITLE
Updated monaco-editor-wrapper 1.3.2 Removing codicon.ttf loading error

### DIFF
--- a/hugo/content/playground/_index.html
+++ b/hugo/content/playground/_index.html
@@ -23,10 +23,10 @@ playground: true
     new URL("", window.location.href).href,
     false
   );
-
+  
+  // helper function for adding monaco styles with embedded codicon TTF
   MonacoEditorLanguageClientWrapper.addMonacoStyles("monaco-editor-styles");
-  MonacoEditorLanguageClientWrapper.addCodiconTtf();
-
+  
   addEventListener('load', function() {
     let getState = null; //: () => PlaygroundParameters
 

--- a/hugo/content/showcase/statemachine.html
+++ b/hugo/content/showcase/statemachine.html
@@ -17,9 +17,9 @@ noMain: true
 
     buildWorkerDefinition('../../libs/monaco-editor-workers/workers', new URL('', window.location.href).href, false);
 
+    // helper function for adding monaco styles with embedded codicon TTF
     MonacoEditorLanguageClientWrapper.addMonacoStyles('monaco-editor-styles');
-    MonacoEditorLanguageClientWrapper.addCodiconTtf();
-
+    
     const client = new MonacoEditorLanguageClientWrapper('42');
     const editorConfig = client.getEditorConfig();
     editorConfig.setMainLanguageId('statemachine');

--- a/hugo/package.json
+++ b/hugo/package.json
@@ -25,7 +25,7 @@
     "langium-statemachine-dsl": "0.5.0-next.f2b3802",
     "lz-string": "^1.4.4",
     "monaco-editor-workers": "0.34.2",
-    "monaco-editor-wrapper": "1.3.1",
+    "monaco-editor-wrapper": "1.3.2",
     "vscode-languageserver": "8.0.2",
     "vite": "^3.2.4"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "langium-statemachine-dsl": "0.5.0-next.f2b3802",
         "lz-string": "^1.4.4",
         "monaco-editor-workers": "0.34.2",
-        "monaco-editor-wrapper": "1.3.1",
+        "monaco-editor-wrapper": "1.3.2",
         "vite": "^3.2.4",
         "vscode-languageserver": "8.0.2"
       }
@@ -2347,26 +2347,26 @@
       "license": "MIT"
     },
     "node_modules/monaco-editor-wrapper": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-1.3.1.tgz",
-      "integrity": "sha512-FRcnmXyJzPwKQopdnKr7jd9XYlc7yWeIzaLkAXfYFQwhyZeMg1pG+5gPnjDmTDTmSSPzjc8dkd00fjF9YoIPcA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-1.3.2.tgz",
+      "integrity": "sha512-I2VXNIJvJ1NAGxUE5oJpYxZH+kRTHXrNptQNocUi2TOlKMUDjFxGb25jx3SB6fCyrmjax8IwZS4oQP00b14kLA==",
       "dev": true,
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.7",
         "monaco-languageclient": "4.0.1",
-        "normalize-url": "7.2.0",
+        "normalize-url": "^8.0.0",
         "vscode": "npm:@codingame/monaco-vscode-api@1.69.12",
         "vscode-languageserver-protocol": "3.17.2",
         "vscode-ws-jsonrpc": "2.0.0"
       }
     },
     "node_modules/monaco-editor-wrapper/node_modules/normalize-url": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
-      "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true,
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5027,7 +5027,7 @@
         "langium-statemachine-dsl": "0.5.0-next.f2b3802",
         "lz-string": "^1.4.4",
         "monaco-editor-workers": "0.34.2",
-        "monaco-editor-wrapper": "1.3.1",
+        "monaco-editor-wrapper": "1.3.2",
         "vite": "^3.2.4",
         "vscode-languageserver": "8.0.2"
       },
@@ -5154,23 +5154,23 @@
       "dev": true
     },
     "monaco-editor-wrapper": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-1.3.1.tgz",
-      "integrity": "sha512-FRcnmXyJzPwKQopdnKr7jd9XYlc7yWeIzaLkAXfYFQwhyZeMg1pG+5gPnjDmTDTmSSPzjc8dkd00fjF9YoIPcA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-1.3.2.tgz",
+      "integrity": "sha512-I2VXNIJvJ1NAGxUE5oJpYxZH+kRTHXrNptQNocUi2TOlKMUDjFxGb25jx3SB6fCyrmjax8IwZS4oQP00b14kLA==",
       "dev": true,
       "requires": {
         "@types/css-font-loading-module": "^0.0.7",
         "monaco-languageclient": "4.0.1",
-        "normalize-url": "7.2.0",
+        "normalize-url": "^8.0.0",
         "vscode": "npm:@codingame/monaco-vscode-api@1.69.12",
         "vscode-languageserver-protocol": "3.17.2",
         "vscode-ws-jsonrpc": "2.0.0"
       },
       "dependencies": {
         "normalize-url": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
-          "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
           "dev": true
         }
       }


### PR DESCRIPTION
codicon.ttf is now directly contained in the css encoded as base64 data url. Therefore only one helper function is needed and the path error in the console is gone.