### PR TITLE
Remove error color

### DIFF
--- a/hugo/static/custom.css
+++ b/hugo/static/custom.css
@@ -169,6 +169,9 @@
     }
 }
 
+:root .chroma .err {
+    background-color: transparent;   
+}
 
 .gdoc-markdown h1,
 h2,


### PR DESCRIPTION
When Chroma encountered a TypeScript syntax error (even though there wasn't), it displayed a white box. This change removes the background color for errors.