### PR TITLE
Improve syntax highlight for light theme

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -3,8 +3,6 @@ title = "Langium"
 theme = "hugo-geekdoc"
 
 # Required to get well formatted code blocks
-pygmentsUseClasses = true
-pygmentsCodeFences = true
 disablePathToLower = true
 enableGitInfo = true
 # Required if you want to render robots.txt template
@@ -14,6 +12,8 @@ enableRobotsTXT = true
   [markup.goldmark.renderer]
     # Needed for mermaid shortcode
     unsafe = true
+  [markup.highlight]
+    codeFences = false  # Disable Hugo's code highlighter as it conflicts with prism's highligher.
   [markup.tableOfContents]
     startLevel = 1
     endLevel = 9

--- a/hugo/content/docs/sematic-model.md
+++ b/hugo/content/docs/sematic-model.md
@@ -20,7 +20,7 @@ The simplest way to write a parser rule is as follows:
 X: name=ID;
 ```
 With this syntax, Langium will **infer** the type of the node to be generated when parsing the rule. By convention, the type of the node will be named after the name of the rule, resulting in this **TypeScript interface** in the semantic model:
-```ts
+```langium
 interface X extends AstNode {
     name: string
 }
@@ -30,7 +30,7 @@ It is also possible to control the naming of the interface by using the followin
 X infers MyType: name=ID;
 ```
 resulting in the following interface in the semantic model:
-```ts
+```langium
 interface MyType extends AstNode {
     name: string
 }
@@ -45,7 +45,7 @@ X infers MyType: name=ID;
 Y infers MyType: name=ID count=INT;
 ```
 This result in the creation of a single interface in the semantic model 'merging' the two parser rules with non-common properties made optional:
-```ts
+```langium
 interface MyType extends AstNode {
     count?: number
     name: string
@@ -61,7 +61,7 @@ terminal ID returns string: /[a-zA-Z_][a-zA-Z0-9_]*/;
 X: name=ID count=INT;
 ```
 
-```ts
+```langium
 // generated interface
 interface X extends AstNode {
     name: string
@@ -79,7 +79,7 @@ QualifiedName returns string: ID '.' ID;
 X: name=QualifiedName;
 ```
 
-```ts
+```langium
 // generated types
 type QualifiedName = string;
 
@@ -99,7 +99,7 @@ There are three available kinds of [assignments](../grammar-language/#assignment
 X: name=ID numbers+=INT (numbers+=INT)* isValid?='valid'?;
 ```
 
-```ts
+```langium
 // generated interface
 interface X extends AstNode {
     name: string
@@ -120,7 +120,7 @@ X: 'x' name=ID;
 Y: crossValue=[X:ID] alt=(INT | X | [X:ID]);
 ```
 
-```ts
+```langium
 // generated types
 interface X extends AstNode {
     name: string
@@ -141,10 +141,9 @@ X: A | B;
 
 A: 'A' name=ID;
 B: 'B' name=ID count=INT;
-
 ```
 
-```ts
+```langium
 // generated types
 type X = A | B;
 
@@ -173,7 +172,7 @@ A: 'A' name=ID;
 B: 'B' name=ID count=INT;
 ```
 
-```ts
+```langium
 // generated types
 type X = A | B;
 
@@ -305,9 +304,11 @@ Y returns MyOtherType: name=ID count=INT;
 
 Explicitly declaring union types in the grammar is achieved with the keyword `type`:
 
-```ts
+```langium
 type X = A | B;
+```
 
+```langium
 // generates:
 type X = A | B;
 ```

--- a/hugo/static/prism/langium-prism.js
+++ b/hugo/static/prism/langium-prism.js
@@ -21,7 +21,7 @@ Prism.languages.langium = {
         pattern: /\b(interface|fragment|terminal|boolean|current|extends|grammar|returns|bigint|hidden|import|infers|number|string|entry|false|infer|Date|true|type|with)\b/
     },
     property: {
-        pattern: /\b[a-z][\w]*(?==|\?=|\+=|:|>)\b/
+        pattern: /\b[a-z][\w]*(?==|\?=|\+=|\??:|>)\b/
     },
     entity: {
         pattern: /\b[A-Z][\w]*\b/

--- a/hugo/static/prism/prism.css
+++ b/hugo/static/prism/prism.css
@@ -10,7 +10,7 @@ https://prismjs.com/download.html#themes=prism-dark */
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #6A9955;
+    color: var(--token-comment);
 }
 
 .token.punctuation {
@@ -27,7 +27,7 @@ https://prismjs.com/download.html#themes=prism-dark */
 .token.number,
 .token.constant,
 .token.symbol {
-    color: #9CDCFE;
+    color: var(--token-constants);
 }
 
 .token.selector,
@@ -36,44 +36,46 @@ https://prismjs.com/download.html#themes=prism-dark */
 .token.char,
 .token.builtin,
 .token.inserted {
-    color: #CE9178;
+    color: var(--token-string);
 }
 
 .token.operator,
 .token.entity,
 .token.url,
-.token.variable {
-    color: #4EC9B0;
-}
-
+.token.variable,
 .token.class {
-    color: #4EC9B0;
+    color: var(--token-entity);
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-    color: #569CD6;
+    color: var(--token-keyword);
 }
 
 .token.regex,
 .token.important {
-    color: #D16969;
+    color: var(--token-regex);
 }
 
-.token.important,
-.token.bold {
-    font-weight: bold;
+:root,
+:root[color-mode="light"] {
+    --token-comment: #008000;
+        --token-constants: #001080;
+        --token-string: #A31515;
+        --token-entity: #267F99;
+        --token-keyword: #0000FF;
+        --token-regex: #D16969;
 }
 
-.token.italic {
-    font-style: italic;
+@media (prefers-color-scheme: dark) {
+    :root {
+        --token-comment: #6A9955;
+        --token-constants: #9CDCFE;
+        --token-string: #CE9178;
+        --token-entity: #4EC9B0;
+        --token-keyword: #569CD6;
+        --token-regex: #D16969;
+    }
 }
 
-.token.entity {
-    cursor: help;
-}
-
-.token.deleted {
-    color: red;
-}

--- a/hugo/static/prism/prism.css
+++ b/hugo/static/prism/prism.css
@@ -61,11 +61,11 @@ https://prismjs.com/download.html#themes=prism-dark */
 :root,
 :root[color-mode="light"] {
     --token-comment: #008000;
-        --token-constants: #001080;
-        --token-string: #A31515;
-        --token-entity: #267F99;
-        --token-keyword: #0000FF;
-        --token-regex: #D16969;
+    --token-constants: #001080;
+    --token-string: #A31515;
+    --token-entity: #267F99;
+    --token-keyword: #0000FF;
+    --token-regex: #D16969;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Previously:

![image](https://user-images.githubusercontent.com/4377073/228364330-e4e7ef57-5513-48a5-93f2-faf974f40d39.png)

New:

![image](https://user-images.githubusercontent.com/4377073/228364413-e757416f-9b04-42a5-9393-b4ece768cd5a.png)

Colors are taken from the light/dark default vscode themes.