### PR TITLE
Minor fixes for the builtin library guide

### DIFF
--- a/hugo/content/guides/builtin-library.md
+++ b/hugo/content/guides/builtin-library.md
@@ -53,6 +53,8 @@ As a last step, we have to bind our newly created workspace manager:
 
 ```ts
 // Add this to the `hello-world-module.ts` included in the yeoman generated project
+export type HelloWorldSharedServices = LangiumSharedServices;
+
 export const HelloWorldSharedModule: Module<HelloWorldSharedServices, DeepPartial<LangiumSharedServices>> = {
     workspace: {
         WorkspaceManager: (services) => new HelloWorldWorkspaceManager(services)

--- a/hugo/content/guides/builtin-library.md
+++ b/hugo/content/guides/builtin-library.md
@@ -56,7 +56,7 @@ As a last step, we have to bind our newly created workspace manager:
 // Add this to the `hello-world-module.ts` included in the yeoman generated project
 export type HelloWorldSharedServices = LangiumSharedServices;
 
-export const HelloWorldSharedModule: Module<HelloWorldSharedServices, DeepPartial<LangiumSharedServices>> = {
+export const HelloWorldSharedModule: Module<HelloWorldSharedServices, DeepPartial<HelloWorldSharedServices>> = {
     workspace: {
         WorkspaceManager: (services) => new HelloWorldWorkspaceManager(services)
     }

--- a/hugo/content/guides/builtin-library.md
+++ b/hugo/content/guides/builtin-library.md
@@ -43,6 +43,7 @@ export class HelloWorldWorkspaceManager extends DefaultWorkspaceManager {
         folders: WorkspaceFolder[],
         collector: (document: LangiumDocument<AstNode>) => void
     ): Promise<void> {
+        await super.loadAdditionalDocuments(folders, collector);
         // Load our library using the `builtin` URI schema
         collector(this.documentFactory.fromString(builtinHelloWorld, URI.parse('builtin:///library.hello')));
     }

--- a/hugo/content/guides/builtin-library.md
+++ b/hugo/content/guides/builtin-library.md
@@ -110,7 +110,7 @@ export class DslLibraryFileSystemProvider implements vscode.FileSystemProvider {
         return {
             ctime: date,
             mtime: date,
-            size: builtinHelloWorld.length,
+            size: Buffer.from(builtinHelloWorld).length,
             type: vscode.FileType.File
         };
     }


### PR DESCRIPTION
While following the guide for builtin libraries, I noticed a few places for potential improvements:

- Most importantly: add a type definition for `HelloWorldSharedServices`, because such a type is not generated by yeoman but required for the definition of `HelloWorldSharedModule`.
- Determine the file size via `Buffer.from(...).length`, so the actual byte size of the string is given.
- Add a call `super.loadAdditionalDocuments(folders, collector)`, for the case that the super class defines some additional behavior we might want to keep (though currently not the case).

Let me know what you think about these changes.