### PR TITLE
Documentation on resolving cyclic dependencies

### DIFF
--- a/hugo/content/docs/configuration-services.md
+++ b/hugo/content/docs/configuration-services.md
@@ -146,7 +146,9 @@ export class ServiceClass {
         this.serviceOne = () => services.ServiceOne; // <-- lazy evaluated service
     }
     /* service logic */
-    this.serviceOne().methodOne();
+    method() {
+        this.serviceOne().methodOne();
+    }
 }
 ```
 

--- a/hugo/content/docs/configuration-services.md
+++ b/hugo/content/docs/configuration-services.md
@@ -135,6 +135,21 @@ export class ServiceClass {
 }
 ```
 
+#### Resolving cyclic dependencies
+
+In case one of the services the `ServiceClass` above depends on, also has a dependency back to the `ServiceClass`, your module will throw an error similar to this: `Cycle detected. Please make "ServiceClass" lazy.` Ideally, such cyclic dependencies between services should be avoided. Sometimes, cycles are unavoidable though. In order to make them lazy, assign a lambda function that returns the service in the constructor. You can then invoke this function in your service logic to get access to the depending service:
+```Typescript
+export class ServiceClass {
+    private readonly serviceOne: () => ServiceOne;
+
+    constructor(services: ArithmeticsServices) {
+        this.serviceOne = () => services.ServiceOne; // <-- lazy evaluated service
+    }
+    /* service logic */
+    this.serviceOne().methodOne();
+}
+```
+
 #### Using ArithmeticsValidator in other services
 The `ArithmeticsValidator` needs to be registered inside of the `ValidationRegistry`. This done by [overriding](#overriding-and-extending-services) `ValidationRegistry` with `ArithmeticsValidationRegistry`.
 


### PR DESCRIPTION
The documentation on customizing your language editor with additional services in docs/configuration-services.md was lacking a section on how to resolve cyclic dependencies. Langium will throw an error in case of such cyclic dependencies that links to a non-existing documentation page. Once this PR is merged and published, the error message in Langium may be updated to refer to this new section: https://langium.org/docs/configuration-services/#resolving-cyclic-dependencies