### PR TITLE
Hotfix: Changed the arithmetics description

### DIFF
--- a/hugo/content/showcase/arithmetics.html
+++ b/hugo/content/showcase/arithmetics.html
@@ -6,7 +6,7 @@ layout: showcase-page
 url: "/showcase/arithmetics"
 img: "/assets/Langium_Arithmetics.svg"
 file: "scripts/arithmetics/arithmetics.tsx"
-description: A language that demostrates a simple arithmetics language.
+description: A language for arithmetic calculations. It supports definitions of functions and intermediate values.
 geekdochidden: true
 draft: false
 noMain: true


### PR DESCRIPTION
Just changed the description from
![image](https://github.com/langium/langium-website/assets/68400102/8bc53749-9d35-43ca-be72-61e3d5719fe4)
to 
![image](https://github.com/langium/langium-website/assets/68400102/024a1dea-5add-4c8b-ab89-7f5da52ba5cf)
