### PR TITLE
Update esbuild config for new versions

### DIFF
--- a/hugo/content/guides/code-bundling.md
+++ b/hugo/content/guides/code-bundling.md
@@ -39,8 +39,8 @@ if (watch) {
     await ctx.watch();
 } else {
     await ctx.rebuild();
+    ctx.dispose();
 }
-ctx.dispose();
 ```
 
 Store it in a module JavaScript file (`.mjs`) and create a corresponding script in your `package.json` file:


### PR DESCRIPTION
With newer versions of esbuild, the build/watch API has changed quite a bit. This change updates our documentation to reflect that.