### PR TITLE
Handle Failed Editor Disposal

### DIFF
--- a/hugo/content/playground/common.ts
+++ b/hugo/content/playground/common.ts
@@ -222,7 +222,12 @@ const PlaygroundActions: Actions = {
 
     if (editor) {
       content = editor.editor.getMainCode();
-      await editor.editor.dispose();
+      // attempt to dispose
+      await editor.editor.dispose().catch((e) => {
+        // report & discard this error
+        // can happen when a previous editor was not started correctly
+        console.error(e);
+      });
     }
 
     const { Grammar } = await createServicesForGrammar({ grammar: message.grammar });


### PR DESCRIPTION
Closes #163 , where the second program editor instance would crash due to not getting a correct grammar from the previous editor. In such a case there was no program editor to dispose of for future grammars, which would block the program editor from being setup again from that point forward. This just catches errors during the editor disposal process (such as trying to dispose a non-running editor), reports them, and unblocks subsequent setup of a new program editor.

Quick gif of the result below.
![Jul-19-2023 17-05-46](https://github.com/langium/langium-website/assets/5070304/db2d9c8f-a037-4bd5-a2d4-1691d8fdcfef)
