### PR TITLE
Fix import on keywords-as-identifiers recipe

### DIFF
--- a/hugo/content/docs/recipes/keywords-as-identifiers/_index.md
+++ b/hugo/content/docs/recipes/keywords-as-identifiers/_index.md
@@ -87,7 +87,8 @@ In Langium, the `SemanticTokenProvider` service is responsible for assigning lan
 Therefore, we customize the default semantic token provider like this:
 
 ```ts
-import { AbstractSemanticTokenProvider, AstNode, SemanticTokenAcceptor } from 'langium';
+import { AstNode } from 'langium';
+import { AbstractSemanticTokenProvider, SemanticTokenAcceptor } from 'langium/lsp';
 import { isPerson } from './generated/ast.js';
 import { SemanticTokenTypes } from 'vscode-languageserver';
 


### PR DESCRIPTION
`langium` has no exported member _AbstractSemanticTokenProvider_ or _SemanticTokenAcceptor_. These should be imported from `langium/lsp`.