### PR TITLE
Fix domain-model example

### DIFF
--- a/hugo/assets/scripts/domainmodel/domainmodel-tools.ts
+++ b/hugo/assets/scripts/domainmodel/domainmodel-tools.ts
@@ -45,7 +45,7 @@ export function getMainTreeNode(ast: AstNode): TreeNode {
 
         // get all children of an Entity (including the supertype)
         const getChildren = (e: Entity): TreeNode[] => {
-            const superType = astNode.entities.find(entity => entity.name === e.superType?.ref.name);
+            const superType = astNode.entities.find(entity => entity.name === e.superType?.ref?.name);
             const features = e.features.map(f => getFeatureTreeNode(f));
 
             const children: TreeNode[] = superType ? [...features, { 

--- a/hugo/assets/scripts/domainmodel/domainmodel.tsx
+++ b/hugo/assets/scripts/domainmodel/domainmodel.tsx
@@ -142,7 +142,7 @@ class App extends React.Component<{}, AppState> {
 
 
 userConfig = createUserConfig({
-    languageId: 'domainmodel',
+    languageId: 'dmodel',
     code: example,
     worker: '../../showcase/libs/worker/domainmodelServerWorker.js',
     monarchGrammar: syntaxHighlighting


### PR DESCRIPTION
As of version 4 of Langium, each file (by default) needs the correct file extension. This change adjusts the generated URI to match that.